### PR TITLE
feat: Show grey spent/exited chip for 0 balance

### DIFF
--- a/src/components/PoolAccountTable.tsx
+++ b/src/components/PoolAccountTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, MouseEvent } from 'react';
+import { useState, MouseEvent, useMemo } from 'react';
 import { OverflowMenuVertical } from '@carbon/icons-react';
 import {
   styled,
@@ -90,6 +90,13 @@ export const PoolAccountTable = ({ records }: { records: PoolAccount[] }) => {
     setAnchorEl(Array(poolAccounts.length).fill(null));
   };
 
+  const getRowReviewStatus = useMemo(
+    () => (row: PoolAccount) => {
+      return row.reviewStatus === ReviewStatus.APPROVED && row.balance === 0n ? ReviewStatus.SPENT : row.reviewStatus;
+    },
+    [],
+  );
+
   const getExitHandler = (row: PoolAccount) => {
     return row.balance !== 0n ? () => handleExit(row) : undefined;
   };
@@ -145,11 +152,11 @@ export const PoolAccountTable = ({ records }: { records: PoolAccount[] }) => {
 
                   <STableCell sx={{ paddingRight: mobile ? 0 : '1rem', textAlign: 'center' }}>
                     <Tooltip
-                      title={row.reviewStatus === ReviewStatus.PENDING ? statusMessage : ''}
+                      title={getRowReviewStatus(row) === ReviewStatus.PENDING ? statusMessage : ''}
                       placement='top'
                       disableInteractive
                     >
-                      <StatusChip status={row.reviewStatus} compact={mobile} />
+                      <StatusChip status={getRowReviewStatus(row)} compact={mobile} />
                     </Tooltip>
                   </STableCell>
 

--- a/src/components/StatusChip.tsx
+++ b/src/components/StatusChip.tsx
@@ -28,7 +28,14 @@ export const SStatusChip = styled(Box, {
     approved: theme.palette.success,
     pending: theme.palette.warning,
     declined: theme.palette.error,
-    exited: theme.palette.success,
+    exited: {
+      main: theme.palette.grey[500],
+      light: theme.palette.grey[100],
+    },
+    spent: {
+      main: theme.palette.grey[600],
+      light: theme.palette.grey[50],
+    },
   };
 
   return {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -9,6 +9,7 @@ export enum ReviewStatus {
   APPROVED = 'approved',
   DECLINED = 'declined',
   EXITED = 'exited',
+  SPENT = 'spent',
 }
 
 export type Event = {


### PR DESCRIPTION
fixes issue #30

I grayed exited and set spent to white to note the slight difference but I can grey both if preferred.

![Screenshot from 2025-06-02 13-57-30](https://github.com/user-attachments/assets/95c12d2e-8bab-4225-a401-26bf96a35979)
