### PR TITLE
feat: Move HYPERSYNC_KEY to server-side w/ proxy

### DIFF
--- a/src/app/api/hypersync-rpc/route.ts
+++ b/src/app/api/hypersync-rpc/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerEnv } from '~/config/env';
+
+const { HYPERSYNC_KEY } = getServerEnv();
+
+export async function POST(request: NextRequest) {
+  try {
+    // Get the full JSON-RPC request body
+    const rpcRequest = await request.json();
+
+    // Extract chainId from the URL search params or request body
+    const url = new URL(request.url);
+    const chainId = url.searchParams.get('chainId') || rpcRequest.chainId;
+
+    if (!chainId) {
+      return NextResponse.json(
+        {
+          jsonrpc: '2.0',
+          error: { code: -32602, message: 'chainId parameter is required' },
+          id: rpcRequest.id || null,
+        },
+        { status: 400 },
+      );
+    }
+
+    // Map chainId to Hypersync endpoint
+    const hypersyncUrls: Record<string, string> = {
+      '1': `https://eth.rpc.hypersync.xyz/${HYPERSYNC_KEY}`, // Mainnet
+      '11155111': `https://sepolia.rpc.hypersync.xyz/${HYPERSYNC_KEY}`, // Sepolia
+    };
+
+    const hypersyncUrl = hypersyncUrls[chainId];
+    if (!hypersyncUrl) {
+      return NextResponse.json(
+        {
+          jsonrpc: '2.0',
+          error: { code: -32602, message: `Unsupported chainId: ${chainId}` },
+          id: rpcRequest.id || null,
+        },
+        { status: 400 },
+      );
+    }
+
+    // Forward the exact JSON-RPC request to Hypersync
+    const response = await fetch(hypersyncUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(rpcRequest),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Hypersync request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return NextResponse.json(data, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
+        'Access-Control-Allow-Credentials': 'false',
+        'Access-Control-Max-Age': '86400',
+      },
+    });
+  } catch (error) {
+    console.error('Hypersync RPC proxy error:', error);
+    return NextResponse.json(
+      {
+        jsonrpc: '2.0',
+        error: { code: -32603, message: 'Internal error' },
+        id: null,
+      },
+      {
+        status: 500,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
+          'Access-Control-Allow-Credentials': 'false',
+          'Access-Control-Max-Age': '86400',
+        },
+      },
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Requested-With',
+      'Access-Control-Allow-Credentials': 'false',
+      'Access-Control-Max-Age': '86400',
+    },
+  });
+}

--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -3,7 +3,7 @@ import { Chain, mainnet, sepolia } from 'viem/chains';
 import { getEnv } from '~/config/env';
 import mainnetIcon from '~/assets/icons/mainnet.svg';
 
-const { ALCHEMY_KEY, IS_TESTNET, ASP_ENDPOINT, HYPERSYNC_KEY } = getEnv();
+const { ALCHEMY_KEY, IS_TESTNET, ASP_ENDPOINT } = getEnv();
 
 // Add chains to the whitelist to be used in the app
 const mainnetChains: readonly [Chain, ...Chain[]] = [mainnet];
@@ -53,7 +53,7 @@ const mainnetChainData: ChainData = {
     image: mainnetIcon.src,
     explorerUrl: mainnet.blockExplorers.default.url,
     relayers: [{ name: 'Freedom Relay', url: 'https://www.freedomrelay.io' }],
-    sdkRpcUrl: `https://eth.rpc.hypersync.xyz/${HYPERSYNC_KEY}`,
+    sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
     aspUrl: ASP_ENDPOINT,
     poolInfo: [
@@ -81,7 +81,7 @@ const testnetChainData: ChainData = {
     decimals: sepolia.nativeCurrency.decimals,
     image: mainnetIcon.src,
     explorerUrl: sepolia.blockExplorers.default.url,
-    sdkRpcUrl: `https://sepolia.rpc.hypersync.xyz/${HYPERSYNC_KEY}`,
+    sdkRpcUrl: `/api/hypersync-rpc?chainId=11155111`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`,
     aspUrl: ASP_ENDPOINT,
     relayers: [

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -9,7 +9,7 @@ const env: Env = {
   SHOW_DISCLAIMER: process.env.NEXT_PUBLIC_SHOW_DISCLAIMER === 'true',
   IS_TESTNET: process.env.NEXT_PUBLIC_IS_TESTNET === 'true',
   GITHUB_HASH: process.env.NEXT_PUBLIC_GITHUB_HASH as string,
-  HYPERSYNC_KEY: process.env.NEXT_PUBLIC_HYPERSYNC_KEY as string,
+  // HYPERSYNC_KEY removed from client-side for security
   SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN as string,
   SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN as string,
 };
@@ -17,6 +17,7 @@ const env: Env = {
 export const getServerEnv = () => {
   return {
     ASP_API_JWT: process.env.ASP_API_JWT as string,
+    HYPERSYNC_KEY: process.env.HYPERSYNC_KEY as string,
   };
 };
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -10,7 +10,7 @@ export interface Env {
   SHOW_DISCLAIMER: boolean;
   IS_TESTNET: boolean;
   GITHUB_HASH: string;
-  HYPERSYNC_KEY: string;
+  // HYPERSYNC_KEY removed from client-side for security
   SENTRY_DSN: string;
   SENTRY_AUTH_TOKEN: string;
 }


### PR DESCRIPTION
- Add HYPERSYNC_KEY to server-side only environment (getServerEnv)
- Create /api/hypersync-rpc proxy endpoint with proper CORS
-  Update chainData.ts to use proxy URLs
- Remove HYPERSYNC_KEY from client-side types
- Remove unused aspClient.ts file