### PR TITLE
fix: withdrawal quote stuck state and incorrect price display

### DIFF
--- a/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
+++ b/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
@@ -233,15 +233,15 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
   }, [isLogged, amountPoolAsset, poolDecimals]);
 
   const myFundsUsd = useMemo(() => {
-    return myFundsToken * (price || 0);
+    return price ? myFundsToken * price : null;
   }, [myFundsToken, price]);
 
   const acceptedFundsUsd = useMemo(() => {
-    return acceptedFundsToken * (price || 0);
+    return price ? acceptedFundsToken * price : null;
   }, [acceptedFundsToken, price]);
 
   const pendingFundsUsd = useMemo(() => {
-    return pendingFundsToken * (price || 0);
+    return price ? pendingFundsToken * price : null;
   }, [pendingFundsToken, price]);
 
   const totalDepositsCount = useMemo(() => {
@@ -363,7 +363,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
   // Calculate user's earned FXN incentives using time-weighted share
   // This accounts for when each deposit was made relative to program start
   const userEarnedFxn = useMemo(() => {
-    if (!incentivesTimeline || !isLogged || acceptedFundsUsd === 0) {
+    if (!incentivesTimeline || !isLogged || !acceptedFundsUsd) {
       return { amount: 0, usdValue: 0 };
     }
 
@@ -398,7 +398,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
       const participationTimeMs = Math.max(0, participationEnd - participationStart);
 
       // Contribution = balance * time participated (in USD terms for weighting)
-      const balanceUsd = balanceToken * (price || 0);
+      const balanceUsd = balanceToken * (price ?? 0);
       userTimeWeightedContribution += balanceUsd * participationTimeMs;
     }
 
@@ -532,7 +532,9 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
           <Grid container>
             <StatsColumn item xs={12} sm={2.4}>
               <AcceptedFundsLabel>Accepted Funds</AcceptedFundsLabel>
-              <AcceptedFundsValue>${formatCompactNumber(acceptedFundsUsd)}</AcceptedFundsValue>
+              <AcceptedFundsValue>
+                {acceptedFundsUsd != null ? `$${formatCompactNumber(acceptedFundsUsd)}` : '-'}
+              </AcceptedFundsValue>
               <AcceptedFundsTokenAmount>
                 {formatCompactNumber(acceptedFundsToken)} {currentPoolInfo?.asset}
               </AcceptedFundsTokenAmount>
@@ -540,7 +542,9 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
 
             <StatsColumn item xs={12} sm={2.4}>
               <AcceptedFundsLabel>Pending Funds</AcceptedFundsLabel>
-              <AcceptedFundsValue>${formatCompactNumber(pendingFundsUsd)}</AcceptedFundsValue>
+              <AcceptedFundsValue>
+                {pendingFundsUsd != null ? `$${formatCompactNumber(pendingFundsUsd)}` : '-'}
+              </AcceptedFundsValue>
               <AcceptedFundsTokenAmount>
                 {formatCompactNumber(pendingFundsToken)} {currentPoolInfo?.asset}
               </AcceptedFundsTokenAmount>
@@ -553,7 +557,9 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
 
             <StatsColumn item xs={12} sm={2.4}>
               <AcceptedFundsLabel>My Funds</AcceptedFundsLabel>
-              <AcceptedFundsValue>${formatCompactNumber(myFundsUsd)}</AcceptedFundsValue>
+              <AcceptedFundsValue>
+                {myFundsUsd != null ? `$${formatCompactNumber(myFundsUsd)}` : '-'}
+              </AcceptedFundsValue>
               <AcceptedFundsTokenAmount>
                 {formatCompactNumber(myFundsToken)} {currentPoolInfo?.asset}
               </AcceptedFundsTokenAmount>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -62,7 +62,7 @@ export const Menu = () => {
 
   const ethBalanceBN = value.toString() ?? '0';
   const balance = formatDataNumber(ethBalanceBN, decimals, 2, false, false, false);
-  const usdBalance = getUsdBalance(price, formatUnits(value, decimals), decimals);
+  const usdBalance = price ? getUsdBalance(price, formatUnits(value, decimals), decimals) : null;
 
   const goTo = useGoTo();
 
@@ -160,7 +160,7 @@ export const Menu = () => {
             {balance}
             <span>{symbol}</span>
           </EthText>
-          <BalanceUsd variant='body2'>{`~ ${usdBalance}`}</BalanceUsd>
+          {usdBalance && <BalanceUsd variant='body2'>{`~ ${usdBalance}`}</BalanceUsd>}
         </Stack>
 
         <SMenuItem onClick={handleCopyAddress}>

--- a/src/containers/AllPoolsStats.tsx
+++ b/src/containers/AllPoolsStats.tsx
@@ -21,7 +21,7 @@ import { formatUnits } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { ChainFilterSelect } from '~/components/ChainFilterSelect';
 import { InfoTooltip } from '~/components/InfoTooltip';
-import { allPoolsChainData, getConfig, PoolInfo } from '~/config';
+import { allPoolsChainData, chainData, getConfig, PoolInfo } from '~/config';
 import { PAContainer, Section } from '~/containers';
 import { useChainContext } from '~/hooks';
 import type { PoolResponse } from '~/types';
@@ -483,9 +483,11 @@ export const AllPoolsStats = () => {
   const { ASP_ENDPOINT_TEST, ASP_ENDPOINT_NON_TEST } = getConfig().env;
 
   // Fetch incentives stats for fxUSD pool (uses avg TVL for APR calculation)
+  const fxusdPoolScope = chainData[1]?.poolInfo.find((p) => p.asset === 'fxUSD')?.scope?.toString();
   const { data: fxusdIncentivesStats } = useQuery({
-    queryKey: ['pool_incentives_stats', 'fxusd', ASP_ENDPOINT_NON_TEST],
-    queryFn: () => aspClient.fetchPoolIncentivesStats(ASP_ENDPOINT_NON_TEST, 1, 'fxusd', 7),
+    queryKey: ['pool_incentives_stats', fxusdPoolScope, ASP_ENDPOINT_NON_TEST],
+    queryFn: () => aspClient.fetchPoolIncentivesStats(ASP_ENDPOINT_NON_TEST, 1, fxusdPoolScope!, 7),
+    enabled: !!fxusdPoolScope,
     staleTime: 300000, // 5 minutes
     refetchInterval: 300000,
     retry: 2,

--- a/src/containers/Modals/ActivityDetails/DataSection.tsx
+++ b/src/containers/Modals/ActivityDetails/DataSection.tsx
@@ -49,22 +49,22 @@ export const DataSection = () => {
   const fees = isWithdrawal && onChainFee !== null ? onChainFee : calculatedFees;
 
   const feeFormatted = formatDataNumber(fees, decimals);
-  const feeUSD = getUsdBalance(price, formatUnits(fees, decimals), decimals);
-  const feeText = isFeeLoading ? 'Loading...' : `${feeFormatted} ${asset} (~ ${feeUSD} USD)`;
+  const feeUSD = price ? getUsdBalance(price, formatUnits(fees, decimals), decimals) : null;
+  const feeText = isFeeLoading ? 'Loading...' : `${feeFormatted} ${asset}${feeUSD ? ` (~ ${feeUSD} USD)` : ''}`;
 
   const feesCollectorAddress = isDeposit ? entryPointAddress : currentSelectedRelayerData?.relayerAddress;
   const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress ?? '0x')})`;
 
   const totalText = isDeposit ? formatUnits(originalAmount, decimals) : formatUnits(amountInWei, decimals);
-  const totalUSD = getUsdBalance(price, totalText, decimals);
-  const valueText = `~${totalText.slice(0, 6)} ${asset} (~ ${totalUSD} USD)`;
+  const totalUSD = price ? getUsdBalance(price, totalText, decimals) : null;
+  const valueText = `~${totalText.slice(0, 6)} ${asset}${totalUSD ? ` (~ ${totalUSD} USD)` : ''}`;
 
   // Use on-chain received amount for withdrawals if available
   const amountWithFee = isWithdrawal && actualReceivedAmount !== null ? actualReceivedAmount : originalAmount - fees;
-  const amountWithFeeUSD = getUsdBalance(price, formatUnits(amountWithFee, decimals), decimals);
+  const amountWithFeeUSD = price ? getUsdBalance(price, formatUnits(amountWithFee, decimals), decimals) : null;
   const receivedText = isFeeLoading
     ? 'Loading...'
-    : `${formatUnits(amountWithFee, decimals)} ${asset} (~ ${amountWithFeeUSD} USD)`;
+    : `${formatUnits(amountWithFee, decimals)} ${asset}${amountWithFeeUSD ? ` (~ ${amountWithFeeUSD} USD)` : ''}`;
 
   // const poolAccountName = useMemo(() => {
   //   const name = poolAccounts.find((pool) => pool.label === selectedHistoryData?.commitment?.preimage?.label)?.name;

--- a/src/containers/Modals/ActivityDetails/Resume.tsx
+++ b/src/containers/Modals/ActivityDetails/Resume.tsx
@@ -20,7 +20,9 @@ export const Resume = () => {
   const decimals = assetDecimals ?? balanceDecimals ?? 18;
 
   const amount = formatUnits(selectedHistoryData?.amount ?? 0n, decimals);
-  const usdBalance = getUsdBalance(price, formatUnits(selectedHistoryData?.amount ?? 0n, decimals), decimals);
+  const usdBalance = price
+    ? getUsdBalance(price, formatUnits(selectedHistoryData?.amount ?? 0n, decimals), decimals)
+    : null;
   const poolAccountName = useMemo(() => {
     const name = poolAccounts.find((pool) => pool.deposit.label === selectedHistoryData?.label)?.name;
     return name ? `PA-${name}` : 'Unknown Pool Account';
@@ -36,7 +38,7 @@ export const Resume = () => {
           {amount}
           <span>{asset}</span>
         </EthText>
-        <BalanceUsd variant='body2'>{`~ ${usdBalance}`}</BalanceUsd>
+        {usdBalance && <BalanceUsd variant='body2'>{`~ ${usdBalance}`}</BalanceUsd>}
       </Stack>
 
       <Stack direction='column' alignItems='end' gap='1.4rem'>

--- a/src/containers/Modals/Deposit/DepositForm.tsx
+++ b/src/containers/Modals/Deposit/DepositForm.tsx
@@ -736,9 +736,9 @@ export const DepositForm = () => {
               data-testid='deposit-input'
             />
             <UsdAmountText>
-              {inputAmount && !isNaN(Number(inputAmount))
+              {inputAmount && !isNaN(Number(inputAmount)) && currentPrice
                 ? `$${(Number(inputAmount) * currentPrice).toFixed(2)}`
-                : '$0.00'}
+                : ''}
             </UsdAmountText>
           </Stack>
 

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
-import { Stack, styled, Typography, IconButton, Collapse, Avatar, Alert } from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { Stack, styled, Typography, IconButton, Collapse, Avatar, Alert, Button } from '@mui/material';
 import { formatUnits, parseUnits, isAddress } from 'viem';
 import { useAccount, useEnsName, useEnsAvatar, usePublicClient } from 'wagmi';
 import { ExtendedTooltip as Tooltip } from '~/components';
@@ -35,6 +36,7 @@ export const DataSection = () => {
   const {
     balanceBN: { symbol, decimals },
     price,
+    refetchPrice,
     selectedPoolInfo,
     chainId,
   } = useChainContext();
@@ -171,12 +173,14 @@ export const DataSection = () => {
   const amountWithFeeBN = parseUnits(amount, decimals) - fees;
   const amountWithFee = formatUnits(amountWithFeeBN, decimals);
   const amountWithFeeUSD = getUsdBalance(price, amountWithFee, decimals);
-  const valueText = `${parseFloat(amountWithFee).toString()} ${displaySymbol} (~$${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)} USD)`;
+  const valueText = price
+    ? `${parseFloat(amountWithFee).toString()} ${displaySymbol} (~$${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)} USD)`
+    : `${parseFloat(amountWithFee).toString()} ${displaySymbol}`;
   const valueTooltip = `${formatFullPrecision(amountWithFeeBN, decimals)} ${displaySymbol}`;
 
   // Net Fee calculation (includes extra gas amount if enabled)
   let netFeeAmount = fees;
-  if (quoteState.extraGas && quoteExtraGasAmountETH) {
+  if (quoteState.extraGas && quoteExtraGasAmountETH && price) {
     // Convert extraGasAmountETH from wei to token amount
     const extraGasETH = parseFloat(formatUnits(BigInt(quoteExtraGasAmountETH), 18));
     const extraGasInToken = (extraGasETH * price) / parseFloat(formatUnits(parseUnits('1', decimals), decimals));
@@ -193,7 +197,9 @@ export const DataSection = () => {
   const netFeeNumeric = parseFloat(netFeeFormatted);
   const netFeeDisplayValue = parseFloat(netFeeNumeric.toFixed(netFeePrecision)).toString();
 
-  const netFeeText = `${netFeeDisplayValue} ${displaySymbol} (~$${parseFloat(netFeeUSD.replace('$', '')).toFixed(2)} USD)`;
+  const netFeeText = price
+    ? `${netFeeDisplayValue} ${displaySymbol} (~$${parseFloat(netFeeUSD.replace('$', '')).toFixed(2)} USD)`
+    : `${netFeeDisplayValue} ${displaySymbol}`;
   const netFeeTooltip = `${formatFullPrecision(netFeeAmount, decimals)} ${displaySymbol}`;
 
   const totalAmountBN = parseUnits(amount, decimals);
@@ -326,7 +332,7 @@ export const DataSection = () => {
                 {formatFeeDisplay(totalAmountBN, symbol, decimals, price, isStableAsset).displayText.split(' (~')[0]}
               </TotalAmount>
             </Tooltip>
-            <TotalUSD>${parseFloat(amountUSD.replace('$', '')).toFixed(2)}</TotalUSD>
+            {price && <TotalUSD>${parseFloat(amountUSD.replace('$', '')).toFixed(2)}</TotalUSD>}
           </TotalBox>
 
           <TotalBox>
@@ -336,8 +342,14 @@ export const DataSection = () => {
                 {formatFeeDisplay(amountWithFeeBN, symbol, decimals, price, isStableAsset).displayText.split(' (~')[0]}
               </TotalAmount>
             </Tooltip>
-            <TotalUSD>${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)}</TotalUSD>
+            {price && <TotalUSD>${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)}</TotalUSD>}
           </TotalBox>
+
+          {!price && (
+            <RefetchPriceButton size='small' onClick={refetchPrice} startIcon={<RefreshIcon sx={{ fontSize: 14 }} />}>
+              Load price
+            </RefetchPriceButton>
+          )}
         </TotalsContainer>
       )}
     </Container>
@@ -438,24 +450,19 @@ const FeeBreakdownContainer = styled('div')({
   marginLeft: '16px',
 });
 
-const TotalsContainer = styled('div')(({ theme }) => ({
+const TotalsContainer = styled('div')(() => ({
   display: 'flex',
+  flexWrap: 'wrap',
   marginTop: '24px',
   justifyContent: 'space-between',
   position: 'relative',
-  '&::after': {
-    content: '""',
-    position: 'absolute',
-    left: '50%',
-    top: '0',
-    bottom: '0',
-    width: '1px',
-    backgroundColor: theme.palette.divider,
-    transform: 'translateX(-50%)',
+  '& > button': {
+    width: '100%',
+    justifyContent: 'center',
   },
 }));
 
-const TotalBox = styled('div')(() => ({
+const TotalBox = styled('div')(({ theme }) => ({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
@@ -465,6 +472,9 @@ const TotalBox = styled('div')(() => ({
   backgroundColor: 'transparent',
   minWidth: '208px',
   height: '86px',
+  '& + &': {
+    borderLeft: `1px solid ${theme.palette.divider}`,
+  },
 }));
 
 const TotalLabel = styled(Typography)(({ theme }) => ({
@@ -490,4 +500,20 @@ const TotalUSD = styled(Typography)(({ theme }) => ({
   lineHeight: '18px',
   color: theme.palette.text.secondary,
   textAlign: 'center',
+}));
+
+const RefetchPriceButton = styled(Button)(({ theme }) => ({
+  fontSize: '12px',
+  fontWeight: 500,
+  lineHeight: '16px',
+  color: theme.palette.text.secondary,
+  textTransform: 'none',
+  padding: '2px 8px',
+  minHeight: 0,
+  '&:hover': {
+    color: theme.palette.text.primary,
+  },
+  '& .MuiSvgIcon-root': {
+    fontSize: '14px !important',
+  },
 }));

--- a/src/containers/Modals/Review/FeeBreakdown.tsx
+++ b/src/containers/Modals/Review/FeeBreakdown.tsx
@@ -27,18 +27,13 @@ export const formatFeeDisplay = (
   feeAmount: bigint,
   symbol: string,
   decimals: number,
-  price: number,
+  price: number | null,
   isStableAsset: boolean,
 ): { displayText: string; fullPrecision: string; usdValue: string } => {
   const feeInToken = formatUnits(feeAmount, decimals);
-  const usdValue = getUsdBalance(price, feeInToken, decimals);
 
   // Full precision for tooltip
   const fullPrecision = `${formatUnits(feeAmount, decimals)} ${symbol}`;
-
-  // Parse USD value and ensure 2 decimal places
-  const usdNumeric = parseFloat(usdValue.replace('$', ''));
-  const usdFormatted = `$${usdNumeric.toFixed(2)}`;
 
   // Use the max precision based on asset type - no special cases needed
   const displayPrecision = getMaxDisplayPrecision(isStableAsset);
@@ -49,6 +44,14 @@ export const formatFeeDisplay = (
     feeNumeric < Math.pow(10, -displayPrecision)
       ? feeNumeric.toExponential(2)
       : parseFloat(feeNumeric.toFixed(displayPrecision)).toString();
+
+  if (!price) {
+    return { displayText: `${displayValue} ${symbol}`, fullPrecision, usdValue: '' };
+  }
+
+  const usdValue = getUsdBalance(price, feeInToken, decimals);
+  const usdNumeric = parseFloat(usdValue.replace('$', ''));
+  const usdFormatted = `$${usdNumeric.toFixed(2)}`;
 
   const displayText = `${displayValue} ${symbol} (~${usdFormatted} USD)`;
 
@@ -66,16 +69,8 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
 
   const isStableAsset = selectedPoolInfo?.isStableAsset ?? false;
 
-  // Guard against invalid inputs
-  if (
-    !amount ||
-    amount === '0' ||
-    decimals == null ||
-    !symbol ||
-    price == null ||
-    feeBPS == null ||
-    baseFeeBPS == null
-  ) {
+  // Guard against invalid inputs (price is NOT required — fees display in token units regardless)
+  if (!amount || amount === '0' || decimals == null || !symbol || feeBPS == null || baseFeeBPS == null) {
     return null;
   }
 
@@ -108,7 +103,8 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
       })()
     : null;
   // Use native asset price (e.g., ETH price) for gas fee USD calculation
-  const blockchainFeeUSD = blockchainFeeNative ? (blockchainFeeNative * nativeAssetPrice).toFixed(2) : null;
+  const blockchainFeeUSD =
+    blockchainFeeNative && nativeAssetPrice ? (blockchainFeeNative * nativeAssetPrice).toFixed(2) : null;
 
   // Extra gas amount (convert from wei to native asset)
   const extraGasNative = extraGasAmountETH ? parseFloat(formatUnits(BigInt(extraGasAmountETH), 18)) : null;
@@ -120,7 +116,7 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
       })()
     : null;
   // Use native asset price for extra gas USD calculation
-  const extraGasUSD = extraGasNative ? (extraGasNative * nativeAssetPrice).toFixed(2) : null;
+  const extraGasUSD = extraGasNative && nativeAssetPrice ? (extraGasNative * nativeAssetPrice).toFixed(2) : null;
 
   return (
     <Container>
@@ -178,14 +174,14 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
         {/* Blockchain Fee - shows actual gas cost from relayer */}
         <FeeRow>
           <FeeLabel>Blockchain Fee:</FeeLabel>
-          {blockchainFeeNative && blockchainFeeUSD ? (
+          {blockchainFeeNative ? (
             <Tooltip
               title={
                 <TooltipContent>
                   <div>
                     Amount: {blockchainFeeNativeFormatted} {nativeSymbol}
                   </div>
-                  <div>USD Value: ~${blockchainFeeUSD}</div>
+                  {blockchainFeeUSD && <div>USD Value: ~${blockchainFeeUSD}</div>}
                   <div>Estimated gas cost based on recent similar transactions.</div>
                   <div>Actual cost may vary slightly depending on network conditions.</div>
                 </TooltipContent>
@@ -193,7 +189,8 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
               placement='top'
             >
               <FeeValue>
-                {blockchainFeeNativeFormatted} {nativeSymbol} (~${blockchainFeeUSD})
+                {blockchainFeeNativeFormatted} {nativeSymbol}
+                {blockchainFeeUSD ? ` (~$${blockchainFeeUSD})` : ''}
               </FeeValue>
             </Tooltip>
           ) : (
@@ -202,7 +199,7 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
         </FeeRow>
 
         {/* Gas token received (only show if extraGasAmountETH exists) */}
-        {extraGasNative && extraGasUSD && (
+        {extraGasNative && (
           <>
             <FeeRow>
               <FeeLabel>Gas token received:</FeeLabel>
@@ -212,14 +209,15 @@ export const FeeBreakdown = ({ feeBPS, baseFeeBPS, extraGasAmountETH, relayTxCos
                     <div>
                       Amount: {extraGasNativeFormatted} {nativeSymbol}
                     </div>
-                    <div>USD Value: ~${extraGasUSD}</div>
+                    {extraGasUSD && <div>USD Value: ~${extraGasUSD}</div>}
                     <div>This amount is deducted from your withdrawal to provide {nativeSymbol} for gas fees</div>
                   </TooltipContent>
                 }
                 placement='top'
               >
                 <FeeValue negative>
-                  {extraGasNativeFormatted} {nativeSymbol} (~${extraGasUSD})
+                  {extraGasNativeFormatted} {nativeSymbol}
+                  {extraGasUSD ? ` (~$${extraGasUSD})` : ''}
                 </FeeValue>
               </Tooltip>
             </FeeRow>

--- a/src/containers/Modals/Withdraw/AmountInputSection.tsx
+++ b/src/containers/Modals/Withdraw/AmountInputSection.tsx
@@ -12,7 +12,7 @@ interface AmountInputSectionProps {
   symbol: string;
   poolAccountName: string | undefined;
   balanceUSD: string;
-  currentPrice: number;
+  currentPrice: number | null;
   anonymitySet?: number | null;
   isLoadingAnonymitySet?: boolean;
 }
@@ -40,7 +40,7 @@ export const AmountInputSection = ({
     }
   };
 
-  const usdAmount = amount ? (Number(amount) * currentPrice).toFixed(2) : '0.00';
+  const usdAmount = amount && currentPrice ? (Number(amount) * currentPrice).toFixed(2) : null;
 
   return (
     <Stack width='100%'>
@@ -55,7 +55,7 @@ export const AmountInputSection = ({
             }}
             inputProps={{ maxLength: 20 }}
           />
-          <UsdAmountText>${usdAmount}</UsdAmountText>
+          <UsdAmountText>{usdAmount ? `$${usdAmount}` : ''}</UsdAmountText>
         </Stack>
 
         <Stack direction='column' alignItems='flex-end' gap='8px'>

--- a/src/containers/UserPoolsStats.tsx
+++ b/src/containers/UserPoolsStats.tsx
@@ -263,7 +263,7 @@ const PoolCard = ({
   const myBalance = poolAccounts.reduce((sum, pa) => sum + BigInt(pa.balance || 0), BigInt(0));
   const myBalanceFormatted = formatUnits(myBalance, pool.decimals);
   const myBalanceTokenAmount = Number(myBalanceFormatted);
-  const myBalanceUsd = myBalanceTokenAmount * price;
+  const myBalanceUsd = price ? myBalanceTokenAmount * price : null;
 
   // Calculate pending (sum of balances where reviewStatus is PENDING)
   // Show $0 until the initial deposit status fetch completes to avoid showing incorrect pending values
@@ -306,7 +306,9 @@ const PoolCard = ({
         <StatColumn>
           <StatLabel>My balance</StatLabel>
           <BalanceValue>{myBalanceTokenAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</BalanceValue>
-          <StatSubtext>${myBalanceUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}</StatSubtext>
+          <StatSubtext>
+            {myBalanceUsd != null ? `$${myBalanceUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : ''}
+          </StatSubtext>
         </StatColumn>
         <StatColumn align='right'>
           <StatLabel>Pending</StatLabel>
@@ -335,7 +337,7 @@ const BalanceOnlyCard = ({
   const myBalance = poolAccounts.reduce((sum, pa) => sum + BigInt(pa.balance || 0), BigInt(0));
   const myBalanceFormatted = formatUnits(myBalance, pool.decimals);
   const myBalanceTokenAmount = Number(myBalanceFormatted);
-  const myBalanceUsd = myBalanceTokenAmount * price;
+  const myBalanceUsd = price ? myBalanceTokenAmount * price : null;
 
   const handleClick = () => {
     router.push(`/pools/${pool.chainId}/${pool.asset.toLowerCase()}`);
@@ -366,7 +368,9 @@ const BalanceOnlyCard = ({
         <StatColumn>
           <StatLabel>My balance</StatLabel>
           <BalanceValue>{myBalanceTokenAmount.toLocaleString(undefined, { maximumFractionDigits: 4 })}</BalanceValue>
-          <StatSubtext>${myBalanceUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}</StatSubtext>
+          <StatSubtext>
+            {myBalanceUsd != null ? `$${myBalanceUsd.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : ''}
+          </StatSubtext>
         </StatColumn>
       </StatsRow>
     </SinglePoolCardContainer>

--- a/src/contexts/QuoteContext.tsx
+++ b/src/contexts/QuoteContext.tsx
@@ -68,7 +68,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
         extraGasAmountETH,
         relayTxCostETH,
         countdown,
-        isExpired: false,
+        isExpired: countdown <= 0, // Mark as expired immediately if countdown is already 0 (e.g., clock skew)
         extraGas: prev.extraGas, // Preserve current extraGas setting
         quotedAmount,
         pendingQuoteRequest: false, // Clear pending request when quote is set

--- a/src/hooks/useRequestQuote.ts
+++ b/src/hooks/useRequestQuote.ts
@@ -103,6 +103,10 @@ export const useRequestQuote = ({
 
       const remainingTime = calculateRemainingTime(newQuoteData.feeCommitment.expiration);
 
+      if (remainingTime <= 0) {
+        addNotification('warning', 'Quote expired immediately. Your system clock may be inaccurate.');
+      }
+
       expiredNotificationSentRef.current = null;
 
       setQuoteData(

--- a/src/providers/ChainProvider.tsx
+++ b/src/providers/ChainProvider.tsx
@@ -28,8 +28,9 @@ type ContextType = {
   balanceInPoolBN: string;
   setChainId: (value: number) => void;
   setBalanceInPool: (val: string) => void;
-  price: number;
-  nativeAssetPrice: number;
+  price: number | null;
+  nativeAssetPrice: number | null;
+  refetchPrice: () => void;
   maxDeposit: string;
   selectedRelayer: SelectedRelayerType | undefined;
   setSelectedRelayer: (value: SelectedRelayerType | undefined) => void;
@@ -61,8 +62,8 @@ export const ChainProvider = ({ children }: Props) => {
   const [chainId, setChainId] = useState(whitelistedChains[0].id);
   const { addNotification } = useNotifications();
   const [balanceInPoolBN, setBalanceInPool] = useState<string>(parseEther('100').toString());
-  const [price, setPrice] = useState<number>(0);
-  const [nativeAssetPrice, setNativeAssetPrice] = useState<number>(0);
+  const [price, setPrice] = useState<number | null>(null);
+  const [nativeAssetPrice, setNativeAssetPrice] = useState<number | null>(null);
   const [selectedAsset, setSelectedAsset] = useState<ChainAssets>(DEFAULT_ASSET);
   const [selectedRelayer, setSelectedRelayer] = useState<SelectedRelayerType | undefined>(
     () => chainData[chainId].relayers[0],
@@ -144,32 +145,74 @@ export const ChainProvider = ({ children }: Props) => {
     };
   }, [userBalance, selectedAsset]);
 
-  useEffect(() => {
+  const priceRetryRef = useRef(false);
+  const priceFetchIdRef = useRef(0);
+
+  const doFetchPrice = useCallback(() => {
     if (chain && selectedPoolInfo) {
+      const fetchId = ++priceFetchIdRef.current;
+      priceRetryRef.current = false;
+      setPrice(null);
       fetchTokenPrice(selectedAsset, selectedPoolInfo, publicClient)
         .then((data) => {
-          setPrice(data);
+          if (fetchId !== priceFetchIdRef.current) return; // stale — asset changed
+          const fetchedPrice = data || null;
+          // If a non-stablecoin gets a suspicious ~$1 price (likely stale from a previous
+          // stablecoin selection), auto-retry once before accepting it
+          if (fetchedPrice && fetchedPrice <= 1.1 && !selectedPoolInfo.isStableAsset && !priceRetryRef.current) {
+            priceRetryRef.current = true;
+            setPrice(null);
+            fetchTokenPrice(selectedAsset, selectedPoolInfo, publicClient)
+              .then((retryData) => {
+                if (fetchId !== priceFetchIdRef.current) return;
+                setPrice(retryData || null);
+              })
+              .catch(() => {
+                if (fetchId !== priceFetchIdRef.current) return;
+                setPrice(null);
+              });
+            return;
+          }
+          setPrice(fetchedPrice);
         })
         .catch(() => {
-          setPrice(0);
-          addNotification('error', `Error fetching ${selectedAsset} price`);
+          if (fetchId !== priceFetchIdRef.current) return;
+          setPrice(null);
         });
     }
-  }, [addNotification, chain, selectedAsset, selectedPoolInfo, publicClient]);
+  }, [chain, selectedAsset, selectedPoolInfo, publicClient]);
 
-  // Fetch native asset price (e.g., ETH) for gas fee calculations
   useEffect(() => {
+    doFetchPrice();
+  }, [doFetchPrice]);
+
+  const nativePriceFetchIdRef = useRef(0);
+
+  const doFetchNativeAssetPrice = useCallback(() => {
     if (chain) {
+      const fetchId = ++nativePriceFetchIdRef.current;
+      setNativeAssetPrice(null);
       fetchTokenPrice(chain.symbol as ChainAssets)
         .then((data) => {
-          setNativeAssetPrice(data);
+          if (fetchId !== nativePriceFetchIdRef.current) return;
+          setNativeAssetPrice(data || null);
         })
         .catch(() => {
-          setNativeAssetPrice(0);
-          console.error(`Error fetching ${chain.symbol} price for gas calculations`);
+          if (fetchId !== nativePriceFetchIdRef.current) return;
+          setNativeAssetPrice(null);
         });
     }
   }, [chain]);
+
+  // Fetch native asset price (e.g., ETH) for gas fee calculations
+  useEffect(() => {
+    doFetchNativeAssetPrice();
+  }, [doFetchNativeAssetPrice]);
+
+  const refetchPrice = useCallback(() => {
+    doFetchPrice();
+    doFetchNativeAssetPrice();
+  }, [doFetchPrice, doFetchNativeAssetPrice]);
 
   const feesQueries = useQueries({
     queries: activeRelayers.map((relayer) => ({
@@ -248,6 +291,7 @@ export const ChainProvider = ({ children }: Props) => {
       setBalanceInPool: handleSetBalanceInPool,
       price,
       nativeAssetPrice,
+      refetchPrice,
       maxDeposit: selectedPoolInfo?.maxDeposit.toString() ?? '0',
       chainId,
       selectedRelayer,
@@ -271,6 +315,7 @@ export const ChainProvider = ({ children }: Props) => {
       handleSetBalanceInPool,
       price,
       nativeAssetPrice,
+      refetchPrice,
       selectedPoolInfo,
       chainId,
       selectedRelayer,

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -4,10 +4,16 @@ import { EventType, ReviewStatus, StatusObject } from '~/types';
 
 export const getUsdBalance = (price: number | null, balance: string, decimals: number): string => {
   if (!price || !balance || !decimals) return '0';
-  const priceBN = parseUnits(price.toString(), decimals);
-  const balanceBN = parseUnits(balance, decimals);
-  const result = (priceBN * balanceBN) / BigInt(10 ** decimals);
-  return formatDataNumber(result.toString(), decimals, 2, true, false);
+  try {
+    // Truncate price string to avoid exceeding decimal precision for parseUnits
+    const priceStr = price.toFixed(decimals);
+    const priceBN = parseUnits(priceStr, decimals);
+    const balanceBN = parseUnits(balance, decimals);
+    const result = (priceBN * balanceBN) / BigInt(10 ** decimals);
+    return formatDataNumber(result.toString(), decimals, 2, true, false);
+  } catch {
+    return '0';
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary
- Fix withdrawal quote getting stuck at "Getting quote..." when system clock skew causes the quote to arrive already expired (countdown <= 0)
- Fix price showing 1 ETH = $1 USD by switching price state from `0` to `null`, preventing stale stablecoin prices from persisting across pool switches
- Add auto-retry for non-stablecoins that receive suspicious <= $1.10 prices
- Add "Load price" refetch button when price is unavailable instead of showing wrong values
- Fix FeeBreakdown component hiding entirely when price is null — now shows token-denominated fees regardless of price availability
- Fix race condition in price auto-retry where stale callbacks could overwrite the current asset's price after switching pools
- Gracefully hide USD values across all views (PoolPage, ActivityDetails, Menu, UserPoolsStats) when price is unavailable instead of showing $0

## Test plan
- [ ] Switch between stablecoin and ETH pools — verify no stale $1 price persists
- [ ] Disconnect network briefly during price fetch — verify "Load price" button appears instead of $0
- [ ] Request a withdrawal quote on a machine with clock skew — verify it doesn't get stuck
- [ ] Rapidly switch between pools — verify no stale price from previous asset appears
- [ ] Expand fee breakdown during withdrawal — verify token amounts display even if price is loading
- [ ] Check PoolPage stats, Menu wallet balance, and ActivityDetails — verify no $0 USD values when price is unavailable