### PR TITLE
feat: env-configurable maintenance banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,8 +37,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <p>This website requires JavaScript to function properly.</p>
               </NoScriptMessage>
 
-              <Header />
               <MaintenanceBanner />
+              <Header />
               <MainContent data-testid='main-content'>{children}</MainContent>
               <Footer />
             </PageWrapper>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { MainContent, NoScriptMessage, PageWrapper } from '~/components';
 import { FeatureFlagInitializer } from '~/components/FeatureFlagInitializer';
+import { MaintenanceBanner } from '~/components/MaintenanceBanner';
 import { ibm_plex_mono } from '~/config/fonts';
 import { Footer, Header, Modals } from '~/containers';
 import { NotificationContainer } from '~/containers/NotificationContainer';
@@ -37,6 +38,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </NoScriptMessage>
 
               <Header />
+              <MaintenanceBanner />
               <MainContent data-testid='main-content'>{children}</MainContent>
               <Footer />
             </PageWrapper>

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Box, Typography, styled } from '@mui/material';
+
+const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
+const MAINTENANCE_MESSAGE =
+  process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
+  'We are currently in maintenance mode. Withdrawals may be limited. Ragequit (emergency exit) remains available at all times.';
+
+export const MaintenanceBanner = () => {
+  if (!MAINTENANCE_MODE) return null;
+
+  return (
+    <Banner>
+      <BannerText>{MAINTENANCE_MESSAGE}</BannerText>
+    </Banner>
+  );
+};
+
+const Banner = styled(Box)(() => ({
+  width: '100%',
+  backgroundColor: '#FFF3CD',
+  borderBottom: '1px solid #FFECB5',
+  padding: '10px 20px',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 1000,
+}));
+
+const BannerText = styled(Typography)(() => ({
+  fontSize: '13px',
+  fontWeight: 500,
+  color: '#664D03',
+  textAlign: 'center',
+  lineHeight: '1.4',
+}));

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, styled } from '@mui/material';
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
 const MAINTENANCE_MESSAGE =
   process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
-  'We are currently in maintenance mode. Withdrawals may be limited. Emergency exit remains available at all times.';
+  'We are currently in maintenance mode. Withdrawals may be limited. Exit remains available at all times.';
 
 export const MaintenanceBanner = () => {
   if (!MAINTENANCE_MODE) return null;

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -5,7 +5,7 @@ import { Box, Typography, styled } from '@mui/material';
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
 const MAINTENANCE_MESSAGE =
   process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
-  'We are currently in maintenance mode. Withdrawals may be limited. Ragequit (emergency exit) remains available at all times.';
+  'We are currently in maintenance mode. Withdrawals may be limited. Emergency exit remains available at all times.';
 
 export const MaintenanceBanner = () => {
   if (!MAINTENANCE_MODE) return null;

--- a/src/containers/AllPoolsStats.tsx
+++ b/src/containers/AllPoolsStats.tsx
@@ -21,7 +21,7 @@ import { formatUnits } from 'viem';
 import { usePublicClient } from 'wagmi';
 import { ChainFilterSelect } from '~/components/ChainFilterSelect';
 import { InfoTooltip } from '~/components/InfoTooltip';
-import { allPoolsChainData, getConfig, PoolInfo } from '~/config';
+import { allPoolsChainData, chainData, getConfig, PoolInfo } from '~/config';
 import { PAContainer, Section } from '~/containers';
 import { useChainContext } from '~/hooks';
 import type { PoolResponse } from '~/types';
@@ -483,9 +483,11 @@ export const AllPoolsStats = () => {
   const { ASP_ENDPOINT_TEST, ASP_ENDPOINT_NON_TEST } = getConfig().env;
 
   // Fetch incentives stats for fxUSD pool (uses avg TVL for APR calculation)
+  const fxusdPoolScope = chainData[1]?.poolInfo.find((p) => p.asset === 'fxUSD')?.scope?.toString();
   const { data: fxusdIncentivesStats } = useQuery({
-    queryKey: ['pool_incentives_stats', 'fxusd', ASP_ENDPOINT_NON_TEST],
-    queryFn: () => aspClient.fetchPoolIncentivesStats(ASP_ENDPOINT_NON_TEST, 1, 'fxusd', 7),
+    queryKey: ['pool_incentives_stats', fxusdPoolScope, ASP_ENDPOINT_NON_TEST],
+    queryFn: () => aspClient.fetchPoolIncentivesStats(ASP_ENDPOINT_NON_TEST, 1, fxusdPoolScope!, 7),
+    enabled: !!fxusdPoolScope,
     staleTime: 300000, // 5 minutes
     refetchInterval: 300000,
     retry: 2,


### PR DESCRIPTION
## Summary
- Adds a global maintenance banner that displays above the header
- Controlled via `NEXT_PUBLIC_MAINTENANCE_MODE=true` env var
- Custom message via `NEXT_PUBLIC_MAINTENANCE_MESSAGE` (optional)
- Default: "We are currently in maintenance mode. Withdrawals may be limited. Emergency exit remains available at all times."

## Test plan
- [ ] Set `NEXT_PUBLIC_MAINTENANCE_MODE=true` — verify banner appears above header
- [ ] Set custom `NEXT_PUBLIC_MAINTENANCE_MESSAGE` — verify custom text displays
- [ ] Unset/set to false — verify banner is hidden