### PR TITLE
feat: add Privacy Relayer to Ethereum mainnet

### DIFF
--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -132,7 +132,7 @@ const mainnetChainData: ChainData = {
     decimals: mainnet.nativeCurrency.decimals,
     image: mainnetIcon.src,
     explorerUrl: mainnet.blockExplorers.default.url,
-    relayers: [{ name: 'Fast Relay', url: 'https://fastrelay.xyz' }],
+    relayers: [{ name: 'Fast Relay', url: 'https://fastrelay.xyz' }, { name: 'Privacy Relayer', url: 'https://relayerprivacypools4.mooo.com' },],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
     aspUrl: getAspEndpointForChain(mainnet.id),


### PR DESCRIPTION
## Describe your changes
Added a new public relayer to mainnet Ethereum
Relayer URL: https://relayerprivacypools4.mooo.com
Supported assets: ETH
Chain: Ethereum Mainnet (chain ID 1)
Fee: 0.09% (9 BPS)

## Issue ticket number and link
N/A
## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.
