### PR TITLE
feat: add Cloaked Relay for Ethereum mainnet

### DIFF
--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -134,7 +134,7 @@ const mainnetChainData: ChainData = {
     explorerUrl: mainnet.blockExplorers.default.url,
     relayers: [
       { name: 'Fast Relay', url: 'https://fastrelay.xyz' },
-      { name: 'Cloaked Relay', url: 'https://api.clkd.xyz/relayer' },
+      { name: 'Cloaked Relay', url: 'https://api.clkd.xyz' },
     ],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,

--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -132,7 +132,10 @@ const mainnetChainData: ChainData = {
     decimals: mainnet.nativeCurrency.decimals,
     image: mainnetIcon.src,
     explorerUrl: mainnet.blockExplorers.default.url,
-    relayers: [{ name: 'Fast Relay', url: 'https://fastrelay.xyz' }],
+    relayers: [
+      { name: 'Fast Relay', url: 'https://fastrelay.xyz' },
+      { name: 'Cloaked Relay', url: 'https://api.clkd.xyz/relayer' },
+    ],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
     aspUrl: getAspEndpointForChain(mainnet.id),


### PR DESCRIPTION
  ## Summary                                                                                                                                                               
   
  Add Cloaked (https://api.clkd.xyz/relayer) as a relayer for Ethereum                                                                                                                 
  mainnet. Supports all 14 mainnet pools and implements the     
  same API contract as Fast Relay.                                                                                                                                         
                                                                                                                                                                           
  ## Verification                                                                                                                                                          
                                                                                                                                                                           
  Endpoints are live — compare responses side by side:                                                                                                                     
   
  **GET /details**                                                                                                                                                         
  ```bash                                                       
  curl -s 'https://api.clkd.xyz/relayer/details?chainId=1&assetAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' | jq .
  curl -s 'https://fastrelay.xyz/relayer/details?chainId=1&assetAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' | jq .                                                 
                                                                                                                                                                           
  POST /quote                                                                                                                                                              
  curl -s -X POST 'https://api.clkd.xyz/relayer/quote' \                                                                                                                   
    -H 'Content-Type: application/json' \                       
    -d '{"chainId":1,"amount":"1000000000000000000","asset":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","recipient":"0x8a65Ca852EBEFD4c9E405C0c76d7E5E530c07D71","extraGas
  ":false}' | jq .         
```
                                                                                                                                                 
  Mainnet withdrawal relayed successfully via Cloaked public relay:                                                                                                                                 
  https://etherscan.io/tx/0xf1a55ee3ea4afa7e341e464238b3bcb563704de05b288af883819671af1e5583 