### PR TITLE
fix: account for migration banner height on mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { MainContent, NoScriptMessage, PageWrapper } from '~/components';
 import { FeatureFlagInitializer } from '~/components/FeatureFlagInitializer';
-import { MaintenanceBanner } from '~/components/MaintenanceBanner';
 import { ibm_plex_mono } from '~/config/fonts';
 import { Footer, Header, Modals } from '~/containers';
 import { NotificationContainer } from '~/containers/NotificationContainer';
@@ -40,7 +39,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <p>This website requires JavaScript to function properly.</p>
                 </NoScriptMessage>
 
-                <MaintenanceBanner />
                 <Header />
                 <MainContent data-testid='main-content'>{children}</MainContent>
                 <Footer />

--- a/src/components/LayoutComponents.tsx
+++ b/src/components/LayoutComponents.tsx
@@ -23,7 +23,7 @@ export const PageWrapper = styled('main')(({ theme }) => {
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
     [theme.breakpoints.down('sm')]: {
-      paddingTop: `calc(var(--header-height) + var(--banner-height, 0px))`,
+      paddingTop: `calc(var(--header-height) + var(--banner-height, 0px) + var(--maintenance-banner-height, 0px))`,
     },
   };
 });

--- a/src/components/LayoutComponents.tsx
+++ b/src/components/LayoutComponents.tsx
@@ -23,7 +23,7 @@ export const PageWrapper = styled('main')(({ theme }) => {
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
     [theme.breakpoints.down('sm')]: {
-      paddingTop: `var(--header-height)`,
+      paddingTop: `calc(var(--header-height) + var(--banner-height, 0px))`,
     },
   };
 });

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { Box, Typography, styled } from '@mui/material';
 
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
@@ -8,10 +9,29 @@ const MAINTENANCE_MESSAGE =
   'We are currently in maintenance mode. Withdrawals may be limited. Exit remains available at all times.';
 
 export const MaintenanceBanner = () => {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!MAINTENANCE_MODE) {
+      document.body.style.removeProperty('--maintenance-banner-height');
+      return;
+    }
+    const update = () => {
+      const h = bannerRef.current?.offsetHeight ?? 0;
+      document.body.style.setProperty('--maintenance-banner-height', `${h}px`);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      document.body.style.removeProperty('--maintenance-banner-height');
+    };
+  }, []);
+
   if (!MAINTENANCE_MODE) return null;
 
   return (
-    <Banner>
+    <Banner ref={bannerRef}>
       <BannerText>{MAINTENANCE_MESSAGE}</BannerText>
     </Banner>
   );

--- a/src/containers/Header.tsx
+++ b/src/containers/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { styled } from '@mui/material/styles';
 import { Disclaimer, Logo, Menu, SignInButton } from '~/components';
 import { ChainSelect } from '~/components/ChainSelect';
+import { MaintenanceBanner } from '~/components/MaintenanceBanner';
 import { useAuthContext } from '~/hooks';
 import { MigrationBanner } from '~/migration';
 import { zIndex } from '~/utils';
@@ -15,6 +16,7 @@ export const Header = () => {
     <HeaderWrapper>
       <Disclaimer />
       <MigrationBanner />
+      <MaintenanceBanner />
 
       <StyledHeader>
         <LeftSection>

--- a/src/migration/ui/MigrationBanner.tsx
+++ b/src/migration/ui/MigrationBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { alpha, styled, Typography } from '@mui/material';
@@ -9,11 +10,30 @@ const announcementUrl = process.env.NEXT_PUBLIC_MIGRATION_ANNOUNCEMENT_URL;
 
 export const MigrationBanner = () => {
   const { showBanner } = useMigration();
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  // Add banner height to --header-height so mobile content padding-top accounts for it
+  useEffect(() => {
+    if (!showBanner) {
+      document.body.style.removeProperty('--banner-height');
+      return;
+    }
+    const update = () => {
+      const h = bannerRef.current?.offsetHeight ?? 0;
+      document.body.style.setProperty('--banner-height', `${h}px`);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      document.body.style.removeProperty('--banner-height');
+    };
+  }, [showBanner]);
 
   if (!showBanner) return null;
 
   return (
-    <BannerRoot>
+    <BannerRoot ref={bannerRef}>
       <WarningAmberRoundedIcon fontSize='small' />
       <BannerText variant='body2'>
         We strengthened our key generation entropy.


### PR DESCRIPTION
## Summary

On mobile the migration banner was sitting above the fixed header, but the page padding only offset the header height. Content was partially hidden behind the combined banner + header stack and the user couldn't scroll it back into view.

- MigrationBanner now measures itself and sets `--banner-height` on `<body>`
- PageWrapper's mobile `padding-top` adds `var(--banner-height, 0px)` to `var(--header-height)`

## Test plan

- [ ] On mobile with migration banner visible, verify content starts below the header and nothing is hidden
- [ ] On mobile with banner hidden (via env flag), padding stays at header height only
- [ ] Verify no desktop regression