### PR TITLE
Release v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] - 2026-04-14
+
+### Added
+
+- Added Terms of Use and Privacy Policy links to footer
+- Migration banner and maintenance banner are now dismissible (with localStorage persistence)
+
+### Fixed
+
+- Fixed migration banner covering content on mobile (content now offsets for banner height)
+- Collapsed Github/Terms/Privacy into a More dropdown on mobile footer to keep it on a single row
+- Fixed content bleeding through the fixed header on iOS Safari by adding an opaque background
+
 ## [2.2.0] - 2026-03-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.13.0",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import { MainContent, NoScriptMessage, PageWrapper } from '~/components';
 import { FeatureFlagInitializer } from '~/components/FeatureFlagInitializer';
-import { MaintenanceBanner } from '~/components/MaintenanceBanner';
 import { ibm_plex_mono } from '~/config/fonts';
 import { Footer, Header, Modals } from '~/containers';
 import { NotificationContainer } from '~/containers/NotificationContainer';
@@ -40,7 +39,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <p>This website requires JavaScript to function properly.</p>
                 </NoScriptMessage>
 
-                <MaintenanceBanner />
                 <Header />
                 <MainContent data-testid='main-content'>{children}</MainContent>
                 <Footer />

--- a/src/components/LayoutComponents.tsx
+++ b/src/components/LayoutComponents.tsx
@@ -23,7 +23,7 @@ export const PageWrapper = styled('main')(({ theme }) => {
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
     [theme.breakpoints.down('sm')]: {
-      paddingTop: `var(--header-height)`,
+      paddingTop: `calc(var(--header-height) + var(--banner-height, 0px) + var(--maintenance-banner-height, 0px))`,
     },
   };
 });

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { Box, Typography, styled } from '@mui/material';
 
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
@@ -8,10 +9,29 @@ const MAINTENANCE_MESSAGE =
   'We are currently in maintenance mode. Withdrawals may be limited. Exit remains available at all times.';
 
 export const MaintenanceBanner = () => {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!MAINTENANCE_MODE) {
+      document.body.style.removeProperty('--maintenance-banner-height');
+      return;
+    }
+    const update = () => {
+      const h = bannerRef.current?.offsetHeight ?? 0;
+      document.body.style.setProperty('--maintenance-banner-height', `${h}px`);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      document.body.style.removeProperty('--maintenance-banner-height');
+    };
+  }, []);
+
   if (!MAINTENANCE_MODE) return null;
 
   return (
-    <Banner>
+    <Banner ref={bannerRef}>
       <BannerText>{MAINTENANCE_MESSAGE}</BannerText>
     </Banner>
   );

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { Box, Typography, styled } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { Box, IconButton, Typography, styled } from '@mui/material';
 
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
 const MAINTENANCE_MESSAGE =
   process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
   'We are currently in maintenance mode. Withdrawals may be limited. Exit remains available at all times.';
+const DISMISSED_KEY = 'maintenance-banner-dismissed';
 
 export const MaintenanceBanner = () => {
   const bannerRef = useRef<HTMLDivElement>(null);
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!MAINTENANCE_MODE) {
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const isVisible = MAINTENANCE_MODE && dismissed === false;
+
+  useEffect(() => {
+    if (!isVisible) {
       document.body.style.removeProperty('--maintenance-banner-height');
       return;
     }
@@ -26,13 +39,25 @@ export const MaintenanceBanner = () => {
       window.removeEventListener('resize', update);
       document.body.style.removeProperty('--maintenance-banner-height');
     };
-  }, []);
+  }, [isVisible]);
 
-  if (!MAINTENANCE_MODE) return null;
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // ignore storage errors
+    }
+    setDismissed(true);
+  };
+
+  if (!isVisible) return null;
 
   return (
     <Banner ref={bannerRef}>
       <BannerText>{MAINTENANCE_MESSAGE}</BannerText>
+      <DismissButton size='small' onClick={handleDismiss} aria-label='Dismiss maintenance notice'>
+        <CloseRoundedIcon fontSize='small' />
+      </DismissButton>
     </Banner>
   );
 };
@@ -45,6 +70,7 @@ const Banner = styled(Box)(() => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  gap: '0.8rem',
   zIndex: 1000,
 }));
 
@@ -54,4 +80,9 @@ const BannerText = styled(Typography)(() => ({
   color: '#664D03',
   textAlign: 'center',
   lineHeight: '1.4',
+}));
+
+const DismissButton = styled(IconButton)(() => ({
+  color: '#664D03',
+  padding: '0.4rem',
 }));

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -13,6 +13,8 @@ const constants: Constants = {
       label: 'Github',
       href: `https://github.com/0xbow-io/privacy-pools-website`,
     },
+    { label: 'Terms', href: 'https://docs.privacypools.com/toc' },
+    { label: 'Privacy', href: 'https://docs.privacypools.com/privacy-policy' },
   ],
   ASP_OPTIONS: ['0xBow ASP'],
   COOKIES: {

--- a/src/containers/Footer.tsx
+++ b/src/containers/Footer.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import Link from 'next/link';
-import { styled, useMediaQuery } from '@mui/material';
+import { Menu, MenuItem, styled, useMediaQuery } from '@mui/material';
 import { getConfig } from '~/config';
 import { useModal } from '~/hooks';
 import { ModalType } from '~/types';
+
+const MOBILE_MORE_LABELS = ['Github', 'Terms', 'Privacy'];
 
 export const Footer = () => {
   const {
@@ -13,10 +15,16 @@ export const Footer = () => {
     env: { GITHUB_HASH },
   } = getConfig();
   const { setModalOpen } = useModal();
-  const isMobile = useMediaQuery('(max-width:768px)'); // Explicit pixel-based mobile detection
+  const isMobile = useMediaQuery('(max-width:768px)');
+  const [moreAnchor, setMoreAnchor] = useState<null | HTMLElement>(null);
+
   const handleNewsletterClick = () => {
     setModalOpen(ModalType.NEWSLETTER_SUBSCRIPTION);
   };
+
+  const mainLinks = isMobile ? FOOTER_LINKS.filter((item) => !MOBILE_MORE_LABELS.includes(item.label)) : FOOTER_LINKS;
+
+  const moreLinks = isMobile ? FOOTER_LINKS.filter((item) => MOBILE_MORE_LABELS.includes(item.label)) : [];
 
   // GitHub icon SVG
   const GitHubIcon = () => (
@@ -34,26 +42,56 @@ export const Footer = () => {
   return (
     <FooterContainer>
       <Links>
-        {FOOTER_LINKS.map((item) => (
+        {mainLinks.map((item) => (
           <Fragment key={item.label}>
-            <LinkItem style={item.label === 'Github' && isMobile ? { paddingTop: '10px' } : {}}>
+            <LinkItem>
               <Link href={item.href} target='_blank'>
-                {item.label === 'X' && '𝕏'}
-
-                {item.label === 'Github' && isMobile ? (
-                  <LinkHash>
-                    <GitHubIcon /> {GITHUB_HASH && <span>{GITHUB_HASH}</span>}
-                  </LinkHash>
-                ) : (
-                  item.label === 'Github' && 'Github'
-                )}
-
-                {item.label !== 'Github' && item.label !== 'X' && item.label}
+                {item.label === 'X' ? '𝕏' : item.label}
               </Link>
             </LinkItem>
             <VBar>|</VBar>
           </Fragment>
         ))}
+        {isMobile && moreLinks.length > 0 && (
+          <>
+            <LinkItem>
+              <MoreButton
+                type='button'
+                onClick={(e) => setMoreAnchor(e.currentTarget)}
+                aria-haspopup='true'
+                aria-expanded={Boolean(moreAnchor)}
+              >
+                More ▾
+              </MoreButton>
+            </LinkItem>
+            <VBar>|</VBar>
+            <Menu
+              anchorEl={moreAnchor}
+              open={Boolean(moreAnchor)}
+              onClose={() => setMoreAnchor(null)}
+              anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+              transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            >
+              {moreLinks.map((item) => (
+                <MenuItem
+                  key={item.label}
+                  component={Link}
+                  href={item.href}
+                  target='_blank'
+                  onClick={() => setMoreAnchor(null)}
+                >
+                  {item.label === 'Github' ? (
+                    <LinkHash>
+                      <GitHubIcon /> {GITHUB_HASH ? <span>{GITHUB_HASH}</span> : 'Github'}
+                    </LinkHash>
+                  ) : (
+                    item.label
+                  )}
+                </MenuItem>
+              ))}
+            </Menu>
+          </>
+        )}
         <LinkItem>
           <NewsletterLink onClick={handleNewsletterClick}>Newsletter</NewsletterLink>
         </LinkItem>
@@ -135,3 +173,17 @@ const NewsletterLink = styled('span')(({ theme }) => {
     },
   };
 });
+
+const MoreButton = styled('button')(({ theme }) => ({
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+  cursor: 'pointer',
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.caption.fontSize,
+  fontFamily: 'inherit',
+  '&:hover': {
+    fontWeight: 700,
+  },
+}));

--- a/src/containers/Header.tsx
+++ b/src/containers/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { styled } from '@mui/material/styles';
 import { Disclaimer, Logo, Menu, SignInButton } from '~/components';
 import { ChainSelect } from '~/components/ChainSelect';
+import { MaintenanceBanner } from '~/components/MaintenanceBanner';
 import { useAuthContext } from '~/hooks';
 import { MigrationBanner } from '~/migration';
 import { zIndex } from '~/utils';
@@ -15,6 +16,7 @@ export const Header = () => {
     <HeaderWrapper>
       <Disclaimer />
       <MigrationBanner />
+      <MaintenanceBanner />
 
       <StyledHeader>
         <LeftSection>

--- a/src/containers/Header.tsx
+++ b/src/containers/Header.tsx
@@ -47,6 +47,9 @@ const HeaderWrapper = styled('div')(({ theme }) => {
       position: 'fixed',
       top: 0,
       left: 0,
+      // solid background so scrolled content doesn't bleed through the
+      // semi-transparent migration banner on iOS Safari
+      backgroundColor: theme.palette.background.default,
     },
   };
 });

--- a/src/migration/ui/MigrationBanner.tsx
+++ b/src/migration/ui/MigrationBanner.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { alpha, styled, Typography } from '@mui/material';
@@ -9,11 +10,30 @@ const announcementUrl = process.env.NEXT_PUBLIC_MIGRATION_ANNOUNCEMENT_URL;
 
 export const MigrationBanner = () => {
   const { showBanner } = useMigration();
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  // Add banner height to --header-height so mobile content padding-top accounts for it
+  useEffect(() => {
+    if (!showBanner) {
+      document.body.style.removeProperty('--banner-height');
+      return;
+    }
+    const update = () => {
+      const h = bannerRef.current?.offsetHeight ?? 0;
+      document.body.style.setProperty('--banner-height', `${h}px`);
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      document.body.style.removeProperty('--banner-height');
+    };
+  }, [showBanner]);
 
   if (!showBanner) return null;
 
   return (
-    <BannerRoot>
+    <BannerRoot ref={bannerRef}>
       <WarningAmberRoundedIcon fontSize='small' />
       <BannerText variant='body2'>
         We strengthened our key generation entropy.

--- a/src/migration/ui/MigrationBanner.tsx
+++ b/src/migration/ui/MigrationBanner.tsx
@@ -1,20 +1,33 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
-import { alpha, styled, Typography } from '@mui/material';
+import { alpha, IconButton, styled, Typography } from '@mui/material';
 import { useMigration } from '../hooks/useMigration';
 
 const announcementUrl = process.env.NEXT_PUBLIC_MIGRATION_ANNOUNCEMENT_URL;
+const DISMISSED_KEY = 'migration-banner-dismissed';
 
 export const MigrationBanner = () => {
   const { showBanner } = useMigration();
   const bannerRef = useRef<HTMLDivElement>(null);
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
 
-  // Add banner height to --header-height so mobile content padding-top accounts for it
   useEffect(() => {
-    if (!showBanner) {
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const isVisible = showBanner && dismissed === false;
+
+  // Add banner height to --banner-height so mobile content padding-top accounts for it
+  useEffect(() => {
+    if (!isVisible) {
       document.body.style.removeProperty('--banner-height');
       return;
     }
@@ -28,9 +41,18 @@ export const MigrationBanner = () => {
       window.removeEventListener('resize', update);
       document.body.style.removeProperty('--banner-height');
     };
-  }, [showBanner]);
+  }, [isVisible]);
 
-  if (!showBanner) return null;
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // ignore storage errors
+    }
+    setDismissed(true);
+  };
+
+  if (!isVisible) return null;
 
   return (
     <BannerRoot ref={bannerRef}>
@@ -43,6 +65,9 @@ export const MigrationBanner = () => {
           </AnnouncementLink>
         )}
       </BannerText>
+      <DismissButton size='small' onClick={handleDismiss} aria-label='Dismiss announcement'>
+        <CloseRoundedIcon fontSize='small' />
+      </DismissButton>
     </BannerRoot>
   );
 };
@@ -71,4 +96,10 @@ const AnnouncementLink = styled(Link)(({ theme }) => ({
   fontWeight: 600,
   textDecoration: 'underline',
   textUnderlineOffset: '0.3rem',
+}));
+
+const DismissButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  padding: '0.4rem',
+  marginLeft: '0.4rem',
 }));


### PR DESCRIPTION
## Release v2.13.0

### Added

- Added Terms of Use and Privacy Policy links to footer
- Migration banner and maintenance banner are now dismissible (with localStorage persistence)

### Fixed

- Fixed migration banner covering content on mobile (content now offsets for banner height)
- Collapsed Github/Terms/Privacy into a More dropdown on mobile footer to keep it on a single row
- Fixed content bleeding through the fixed header on iOS Safari by adding an opaque background

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.