### PR TITLE
fix: opaque background on mobile header (iOS bleed-through)

### DIFF
--- a/src/containers/Header.tsx
+++ b/src/containers/Header.tsx
@@ -47,6 +47,9 @@ const HeaderWrapper = styled('div')(({ theme }) => {
       position: 'fixed',
       top: 0,
       left: 0,
+      // solid background so scrolled content doesn't bleed through the
+      // semi-transparent migration banner on iOS Safari
+      backgroundColor: theme.palette.background.default,
     },
   };
 });


### PR DESCRIPTION
## Summary

On iOS Safari, scrolled pool content was bleeding through the fixed header stack (pool totals visible behind the migration banner).

Root cause: the migration banner uses `alpha(warning, 0.12)` which is highly transparent, and the `HeaderWrapper` itself had no background.

Add a solid `theme.palette.background.default` background to `HeaderWrapper` at the mobile breakpoint.

## Test plan

- [ ] Scroll the home page on iPhone — content no longer visible through the banner
- [ ] Desktop layout unchanged