### PR TITLE
feat: make migration banner dismissible

### DIFF
--- a/src/migration/ui/MigrationBanner.tsx
+++ b/src/migration/ui/MigrationBanner.tsx
@@ -1,20 +1,34 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
-import { alpha, styled, Typography } from '@mui/material';
+import { alpha, IconButton, styled, Typography } from '@mui/material';
 import { useMigration } from '../hooks/useMigration';
 
 const announcementUrl = process.env.NEXT_PUBLIC_MIGRATION_ANNOUNCEMENT_URL;
+const DISMISSED_KEY = 'migration-banner-dismissed';
 
 export const MigrationBanner = () => {
   const { showBanner } = useMigration();
   const bannerRef = useRef<HTMLDivElement>(null);
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
 
-  // Add banner height to --header-height so mobile content padding-top accounts for it
+  // Read dismissed flag from localStorage after hydration
   useEffect(() => {
-    if (!showBanner) {
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const isVisible = showBanner && dismissed === false;
+
+  // Add banner height to --banner-height so mobile content padding-top accounts for it
+  useEffect(() => {
+    if (!isVisible) {
       document.body.style.removeProperty('--banner-height');
       return;
     }
@@ -28,9 +42,18 @@ export const MigrationBanner = () => {
       window.removeEventListener('resize', update);
       document.body.style.removeProperty('--banner-height');
     };
-  }, [showBanner]);
+  }, [isVisible]);
 
-  if (!showBanner) return null;
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // ignore storage errors
+    }
+    setDismissed(true);
+  };
+
+  if (!isVisible) return null;
 
   return (
     <BannerRoot ref={bannerRef}>
@@ -43,6 +66,9 @@ export const MigrationBanner = () => {
           </AnnouncementLink>
         )}
       </BannerText>
+      <DismissButton size='small' onClick={handleDismiss} aria-label='Dismiss announcement'>
+        <CloseRoundedIcon fontSize='small' />
+      </DismissButton>
     </BannerRoot>
   );
 };
@@ -71,4 +97,10 @@ const AnnouncementLink = styled(Link)(({ theme }) => ({
   fontWeight: 600,
   textDecoration: 'underline',
   textUnderlineOffset: '0.3rem',
+}));
+
+const DismissButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  padding: '0.4rem',
+  marginLeft: '0.4rem',
 }));


### PR DESCRIPTION
## Summary

The migration banner takes ~10% of screen height on mobile and there was no way to dismiss it, which was annoying for repeat visitors who had already seen the message.

- Adds a close button to the banner
- Stores dismissal in localStorage (`migration-banner-dismissed`) so it stays hidden across page loads
- If the env flag turns the banner off and back on later, the flag still works — but users who dismissed it once won't see it again unless they clear storage

## Test plan

- [ ] Banner renders with close button
- [ ] Clicking close hides it and sets localStorage
- [ ] Reloading the page keeps it hidden
- [ ] Clearing localStorage brings it back