### PR TITLE
feat: make migration and maintenance banners dismissible

### DIFF
--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { Box, Typography, styled } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import { Box, IconButton, Typography, styled } from '@mui/material';
 
 const MAINTENANCE_MODE = process.env.NEXT_PUBLIC_MAINTENANCE_MODE === 'true';
 const MAINTENANCE_MESSAGE =
   process.env.NEXT_PUBLIC_MAINTENANCE_MESSAGE ||
   'We are currently in maintenance mode. Withdrawals may be limited. Exit remains available at all times.';
+const DISMISSED_KEY = 'maintenance-banner-dismissed';
 
 export const MaintenanceBanner = () => {
   const bannerRef = useRef<HTMLDivElement>(null);
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!MAINTENANCE_MODE) {
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const isVisible = MAINTENANCE_MODE && dismissed === false;
+
+  useEffect(() => {
+    if (!isVisible) {
       document.body.style.removeProperty('--maintenance-banner-height');
       return;
     }
@@ -26,13 +39,25 @@ export const MaintenanceBanner = () => {
       window.removeEventListener('resize', update);
       document.body.style.removeProperty('--maintenance-banner-height');
     };
-  }, []);
+  }, [isVisible]);
 
-  if (!MAINTENANCE_MODE) return null;
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // ignore storage errors
+    }
+    setDismissed(true);
+  };
+
+  if (!isVisible) return null;
 
   return (
     <Banner ref={bannerRef}>
       <BannerText>{MAINTENANCE_MESSAGE}</BannerText>
+      <DismissButton size='small' onClick={handleDismiss} aria-label='Dismiss maintenance notice'>
+        <CloseRoundedIcon fontSize='small' />
+      </DismissButton>
     </Banner>
   );
 };
@@ -45,6 +70,7 @@ const Banner = styled(Box)(() => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  gap: '0.8rem',
   zIndex: 1000,
 }));
 
@@ -54,4 +80,9 @@ const BannerText = styled(Typography)(() => ({
   color: '#664D03',
   textAlign: 'center',
   lineHeight: '1.4',
+}));
+
+const DismissButton = styled(IconButton)(() => ({
+  color: '#664D03',
+  padding: '0.4rem',
 }));

--- a/src/migration/ui/MigrationBanner.tsx
+++ b/src/migration/ui/MigrationBanner.tsx
@@ -1,20 +1,33 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
-import { alpha, styled, Typography } from '@mui/material';
+import { alpha, IconButton, styled, Typography } from '@mui/material';
 import { useMigration } from '../hooks/useMigration';
 
 const announcementUrl = process.env.NEXT_PUBLIC_MIGRATION_ANNOUNCEMENT_URL;
+const DISMISSED_KEY = 'migration-banner-dismissed';
 
 export const MigrationBanner = () => {
   const { showBanner } = useMigration();
   const bannerRef = useRef<HTMLDivElement>(null);
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
 
-  // Add banner height to --header-height so mobile content padding-top accounts for it
   useEffect(() => {
-    if (!showBanner) {
+    try {
+      setDismissed(localStorage.getItem(DISMISSED_KEY) === '1');
+    } catch {
+      setDismissed(false);
+    }
+  }, []);
+
+  const isVisible = showBanner && dismissed === false;
+
+  // Add banner height to --banner-height so mobile content padding-top accounts for it
+  useEffect(() => {
+    if (!isVisible) {
       document.body.style.removeProperty('--banner-height');
       return;
     }
@@ -28,9 +41,18 @@ export const MigrationBanner = () => {
       window.removeEventListener('resize', update);
       document.body.style.removeProperty('--banner-height');
     };
-  }, [showBanner]);
+  }, [isVisible]);
 
-  if (!showBanner) return null;
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISSED_KEY, '1');
+    } catch {
+      // ignore storage errors
+    }
+    setDismissed(true);
+  };
+
+  if (!isVisible) return null;
 
   return (
     <BannerRoot ref={bannerRef}>
@@ -43,6 +65,9 @@ export const MigrationBanner = () => {
           </AnnouncementLink>
         )}
       </BannerText>
+      <DismissButton size='small' onClick={handleDismiss} aria-label='Dismiss announcement'>
+        <CloseRoundedIcon fontSize='small' />
+      </DismissButton>
     </BannerRoot>
   );
 };
@@ -71,4 +96,10 @@ const AnnouncementLink = styled(Link)(({ theme }) => ({
   fontWeight: 600,
   textDecoration: 'underline',
   textUnderlineOffset: '0.3rem',
+}));
+
+const DismissButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  padding: '0.4rem',
+  marginLeft: '0.4rem',
 }));


### PR DESCRIPTION
## Summary

In production at https://privacypools.com/ both banners (the entropy migration notice and the maintenance mode notice) stack up and take a significant chunk of mobile screen height, with no way to dismiss them.

- Migration banner gets a close button; dismissal persists in localStorage as `migration-banner-dismissed`
- Maintenance banner gets a close button; dismissal persists as `maintenance-banner-dismissed`
- Each banner tracks dismissal independently so users can close one without the other

## Test plan

- [ ] Each banner renders with a close (×) button
- [ ] Clicking × hides just that banner
- [ ] Reloading keeps each dismissed banner hidden
- [ ] Clearing the respective localStorage key brings it back