### PR TITLE
fix middleware missing returns on redirect and next

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,7 @@ export function middleware(request: NextRequest) {
 
   if (userConnected && !userLogged) {
     if (!request.nextUrl.pathname.startsWith(ROUTER.account.base)) {
-      NextResponse.redirect(new URL(ROUTER.account.base, request.url));
+      return NextResponse.redirect(new URL(ROUTER.account.base, request.url));
     }
   }
 
@@ -21,5 +21,5 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  NextResponse.next();
+  return NextResponse.next();
 }


### PR DESCRIPTION
hey team, checked middleware by chance and found the account redirect path was building a redirect response but never returning it, so users who were wallet connected but not logged in basically never got sent to account.

also the end of the function called NextResponse.next() without returning. next middleware should return that response explicitly.

cheers