### PR TITLE
fix: show USD price for BOLD pool

### DIFF
--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -9,6 +9,7 @@ const options = { method: 'GET', headers: { accept: 'application/json' } };
 const STABLECOIN_FALLBACK_PRICES: Record<string, number> = {
   USND: 1.0, // Nerite USD - redeemable for $1 worth of collateral
   BSCUSD: 1.0, // BSC USD - USD-pegged stablecoin on BSC
+  BOLD: 1.0, // Liquity v2 BOLD - soft-pegged USD stablecoin, not listed on Alchemy
 };
 
 // Uniswap V3 FXN/WETH pool on Ethereum mainnet


### PR DESCRIPTION
## What this fixes

In prod the BOLD@Ethereum pool stats render \`-\` instead of dollar amounts for Accepted Funds, Pending Funds and My Funds, so users only see the raw token amount.

## Why

Token prices are pulled from Alchemy's \`prices/v1/.../tokens/by-symbol?symbols=BOLD\` endpoint. Alchemy currently doesn't have BOLD listed and returns:

\`\`\`
{"data":[{"symbol":"BOLD","prices":[],"error":{"message":"Price not found for symbol: BOLD"}}]}
\`\`\`

\`fetchTokenPrice\` then falls through to a \`STABLECOIN_FALLBACK_PRICES\` map for stablecoins Alchemy doesn't cover, but BOLD wasn't in there. BOLD is Liquity v2's USD-pegged stablecoin and is already marked \`isStableAsset: true\` in \`chainData.ts\`, so the same treatment as USND and BSCUSD is appropriate.

## The change

Add \`BOLD: 1.0\` to the fallback map.

## Test plan

* Open the BOLD@Ethereum pool and confirm the stat boxes show a USD value next to each BOLD amount.
* Confirm USND and BSCUSD pools still show their fallback USD values.
* Confirm tokens with real Alchemy prices (USDC, USDT, etc.) still get the live price and aren't overridden.