### PR TITLE
Release v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2026-05-11
+
+### Fixed
+
+- Fixed missing USD price for BOLD, sUSDS, USDe, frxUSD, fxUSD and yUSND pool stats. Live prices fall back to the ASP's reported pool USD value when Alchemy doesn't list the token, which also shows accurate prices for yield-bearing assets like sUSDS instead of pinning them at $1.
+
 ## [2.2.0] - 2026-03-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.13.1",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
+++ b/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
@@ -238,17 +238,40 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
     return Number(formatUnits(amountPoolAsset, poolDecimals));
   }, [isLogged, amountPoolAsset, poolDecimals]);
 
+  // If the chain context can't supply a live price (Alchemy doesn't list the
+  // token, on-chain conversion failed, etc.), derive one from the pool stats
+  // returned by the ASP. This is more accurate than a fixed $1 fallback for
+  // yield-bearing assets like sUSDS/yUSND, which trade above $1 because of
+  // accrued yield.
+  const derivedPriceFromStats = useMemo(() => {
+    const usdStr = currentPoolStats?.acceptedDepositsValueUsd ?? currentPoolStats?.totalInPoolValueUsd;
+    const tokensStr = currentPoolStats?.acceptedDepositsValue ?? currentPoolStats?.totalInPoolValue;
+    if (!usdStr || !tokensStr) return null;
+    const usd = parseFloat(String(usdStr).replace(/,/g, ''));
+    if (!Number.isFinite(usd) || usd <= 0) return null;
+    let tokens: number;
+    try {
+      tokens = Number(formatUnits(BigInt(tokensStr), poolDecimals));
+    } catch {
+      return null;
+    }
+    if (tokens <= 0) return null;
+    return usd / tokens;
+  }, [currentPoolStats, poolDecimals]);
+
+  const effectivePrice = price ?? derivedPriceFromStats;
+
   const myFundsUsd = useMemo(() => {
-    return price ? myFundsToken * price : null;
-  }, [myFundsToken, price]);
+    return effectivePrice ? myFundsToken * effectivePrice : null;
+  }, [myFundsToken, effectivePrice]);
 
   const acceptedFundsUsd = useMemo(() => {
-    return price ? acceptedFundsToken * price : null;
-  }, [acceptedFundsToken, price]);
+    return effectivePrice ? acceptedFundsToken * effectivePrice : null;
+  }, [acceptedFundsToken, effectivePrice]);
 
   const pendingFundsUsd = useMemo(() => {
-    return price ? pendingFundsToken * price : null;
-  }, [pendingFundsToken, price]);
+    return effectivePrice ? pendingFundsToken * effectivePrice : null;
+  }, [pendingFundsToken, effectivePrice]);
 
   const totalDepositsCount = useMemo(() => {
     return currentPoolStats?.totalDepositsCount || 0;
@@ -356,7 +379,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
       const participationTimeMs = Math.max(0, participationEnd - participationStart);
 
       // Contribution = balance * time participated (in USD terms for weighting)
-      const balanceUsd = balanceToken * (price ?? 0);
+      const balanceUsd = balanceToken * (effectivePrice ?? 0);
       userTimeWeightedContribution += balanceUsd * participationTimeMs;
     }
 
@@ -388,7 +411,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
       amount: earnedFxn,
       usdValue,
     };
-  }, [incentivesTimeline, isLogged, acceptedFundsUsd, currentPoolAccounts, poolDecimals, price, fxnPrice]);
+  }, [incentivesTimeline, isLogged, acceptedFundsUsd, currentPoolAccounts, poolDecimals, effectivePrice, fxnPrice]);
 
   useEffect(() => {
     // Parse and set the chain ID

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -9,6 +9,7 @@ const options = { method: 'GET', headers: { accept: 'application/json' } };
 const STABLECOIN_FALLBACK_PRICES: Record<string, number> = {
   USND: 1.0, // Nerite USD - redeemable for $1 worth of collateral
   BSCUSD: 1.0, // BSC USD - USD-pegged stablecoin on BSC
+  BOLD: 1.0, // Liquity v2 BOLD - soft-pegged USD stablecoin, not listed on Alchemy
 };
 
 // Uniswap V3 FXN/WETH pool on Ethereum mainnet

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -10,6 +10,11 @@ const STABLECOIN_FALLBACK_PRICES: Record<string, number> = {
   USND: 1.0, // Nerite USD - redeemable for $1 worth of collateral
   BSCUSD: 1.0, // BSC USD - USD-pegged stablecoin on BSC
   BOLD: 1.0, // Liquity v2 BOLD - soft-pegged USD stablecoin, not listed on Alchemy
+  USDe: 1.0, // Ethena USDe - USD-pegged stablecoin
+  frxUSD: 1.0, // Frax USD - USD-pegged stablecoin
+  fxUSD: 1.0, // f(x) Protocol fxUSD - approximately USD-pegged
+  sUSDS: 1.0, // Sky savings USDS - approximately USD (yield-bearing)
+  yUSND: 1.0, // Nerite yUSND - approximately USD (yield-bearing); kept as fallback in case the on-chain price conversion path can't run
 };
 
 // Uniswap V3 FXN/WETH pool on Ethereum mainnet
@@ -105,6 +110,12 @@ export const fetchTokenPrice = async (
   poolInfo?: PoolInfo,
   publicClient?: PublicClient,
 ): Promise<number> => {
+  // Prefer the canonical asset name from chain config when available — the
+  // caller may pass an upper-cased version coming from the URL slug (e.g.
+  // "SUSDS"), which would miss case-sensitive fallback map lookups for
+  // symbols like "sUSDS", "frxUSD", etc.
+  const symbol = poolInfo?.asset ?? tokenSymbol;
+
   // Check if this token has a custom price conversion
   if (poolInfo?.priceConversion && publicClient) {
     try {
@@ -140,17 +151,17 @@ export const fetchTokenPrice = async (
       const conversionRate = Number(formatUnits(underlyingAmount, poolInfo.assetDecimals || 18));
       return underlyingPrice * conversionRate;
     } catch (error) {
-      console.error(`Error fetching price via conversion for ${tokenSymbol}:`, error);
+      console.error(`Error fetching price via conversion for ${symbol}:`, error);
       // Fall back to direct price fetch
     }
   }
 
   // Standard price fetch from Alchemy
-  const response = await fetch(`${url}symbols=${tokenSymbol}`, options);
+  const response = await fetch(`${url}symbols=${symbol}`, options);
   const json = await response.json();
   const value = json.data?.[0]?.prices?.[0]?.value;
-  if (!value && STABLECOIN_FALLBACK_PRICES[tokenSymbol] !== undefined) {
-    return STABLECOIN_FALLBACK_PRICES[tokenSymbol];
+  if (!value && STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
+    return STABLECOIN_FALLBACK_PRICES[symbol];
   }
   return value || 0;
 };


### PR DESCRIPTION
## Release v2.13.1

### Fixed

- Fixed missing USD price for BOLD, sUSDS, USDe, frxUSD, fxUSD and yUSND pool stats. Live prices fall back to the ASP's reported pool USD value when Alchemy doesn't list the token, which also shows accurate prices for yield-bearing assets like sUSDS instead of pinning them at $1.

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.