### PR TITLE
fix: show USD price for remaining stablecoin pools missing from Alchemy

### DIFF
--- a/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
+++ b/src/app/pools/[chain_id]/[pool_id]/PoolPage.tsx
@@ -238,17 +238,40 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
     return Number(formatUnits(amountPoolAsset, poolDecimals));
   }, [isLogged, amountPoolAsset, poolDecimals]);
 
+  // If the chain context can't supply a live price (Alchemy doesn't list the
+  // token, on-chain conversion failed, etc.), derive one from the pool stats
+  // returned by the ASP. This is more accurate than a fixed $1 fallback for
+  // yield-bearing assets like sUSDS/yUSND, which trade above $1 because of
+  // accrued yield.
+  const derivedPriceFromStats = useMemo(() => {
+    const usdStr = currentPoolStats?.acceptedDepositsValueUsd ?? currentPoolStats?.totalInPoolValueUsd;
+    const tokensStr = currentPoolStats?.acceptedDepositsValue ?? currentPoolStats?.totalInPoolValue;
+    if (!usdStr || !tokensStr) return null;
+    const usd = parseFloat(String(usdStr).replace(/,/g, ''));
+    if (!Number.isFinite(usd) || usd <= 0) return null;
+    let tokens: number;
+    try {
+      tokens = Number(formatUnits(BigInt(tokensStr), poolDecimals));
+    } catch {
+      return null;
+    }
+    if (tokens <= 0) return null;
+    return usd / tokens;
+  }, [currentPoolStats, poolDecimals]);
+
+  const effectivePrice = price ?? derivedPriceFromStats;
+
   const myFundsUsd = useMemo(() => {
-    return price ? myFundsToken * price : null;
-  }, [myFundsToken, price]);
+    return effectivePrice ? myFundsToken * effectivePrice : null;
+  }, [myFundsToken, effectivePrice]);
 
   const acceptedFundsUsd = useMemo(() => {
-    return price ? acceptedFundsToken * price : null;
-  }, [acceptedFundsToken, price]);
+    return effectivePrice ? acceptedFundsToken * effectivePrice : null;
+  }, [acceptedFundsToken, effectivePrice]);
 
   const pendingFundsUsd = useMemo(() => {
-    return price ? pendingFundsToken * price : null;
-  }, [pendingFundsToken, price]);
+    return effectivePrice ? pendingFundsToken * effectivePrice : null;
+  }, [pendingFundsToken, effectivePrice]);
 
   const totalDepositsCount = useMemo(() => {
     return currentPoolStats?.totalDepositsCount || 0;
@@ -356,7 +379,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
       const participationTimeMs = Math.max(0, participationEnd - participationStart);
 
       // Contribution = balance * time participated (in USD terms for weighting)
-      const balanceUsd = balanceToken * (price ?? 0);
+      const balanceUsd = balanceToken * (effectivePrice ?? 0);
       userTimeWeightedContribution += balanceUsd * participationTimeMs;
     }
 
@@ -388,7 +411,7 @@ export const PoolPage = ({ chainId, poolId }: PoolPageProps) => {
       amount: earnedFxn,
       usdValue,
     };
-  }, [incentivesTimeline, isLogged, acceptedFundsUsd, currentPoolAccounts, poolDecimals, price, fxnPrice]);
+  }, [incentivesTimeline, isLogged, acceptedFundsUsd, currentPoolAccounts, poolDecimals, effectivePrice, fxnPrice]);
 
   useEffect(() => {
     // Parse and set the chain ID

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -110,6 +110,12 @@ export const fetchTokenPrice = async (
   poolInfo?: PoolInfo,
   publicClient?: PublicClient,
 ): Promise<number> => {
+  // Prefer the canonical asset name from chain config when available — the
+  // caller may pass an upper-cased version coming from the URL slug (e.g.
+  // "SUSDS"), which would miss case-sensitive fallback map lookups for
+  // symbols like "sUSDS", "frxUSD", etc.
+  const symbol = poolInfo?.asset ?? tokenSymbol;
+
   // Check if this token has a custom price conversion
   if (poolInfo?.priceConversion && publicClient) {
     try {
@@ -145,17 +151,17 @@ export const fetchTokenPrice = async (
       const conversionRate = Number(formatUnits(underlyingAmount, poolInfo.assetDecimals || 18));
       return underlyingPrice * conversionRate;
     } catch (error) {
-      console.error(`Error fetching price via conversion for ${tokenSymbol}:`, error);
+      console.error(`Error fetching price via conversion for ${symbol}:`, error);
       // Fall back to direct price fetch
     }
   }
 
   // Standard price fetch from Alchemy
-  const response = await fetch(`${url}symbols=${tokenSymbol}`, options);
+  const response = await fetch(`${url}symbols=${symbol}`, options);
   const json = await response.json();
   const value = json.data?.[0]?.prices?.[0]?.value;
-  if (!value && STABLECOIN_FALLBACK_PRICES[tokenSymbol] !== undefined) {
-    return STABLECOIN_FALLBACK_PRICES[tokenSymbol];
+  if (!value && STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
+    return STABLECOIN_FALLBACK_PRICES[symbol];
   }
   return value || 0;
 };

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -10,6 +10,11 @@ const STABLECOIN_FALLBACK_PRICES: Record<string, number> = {
   USND: 1.0, // Nerite USD - redeemable for $1 worth of collateral
   BSCUSD: 1.0, // BSC USD - USD-pegged stablecoin on BSC
   BOLD: 1.0, // Liquity v2 BOLD - soft-pegged USD stablecoin, not listed on Alchemy
+  USDe: 1.0, // Ethena USDe - USD-pegged stablecoin
+  frxUSD: 1.0, // Frax USD - USD-pegged stablecoin
+  fxUSD: 1.0, // f(x) Protocol fxUSD - approximately USD-pegged
+  sUSDS: 1.0, // Sky savings USDS - approximately USD (yield-bearing)
+  yUSND: 1.0, // Nerite yUSND - approximately USD (yield-bearing); kept as fallback in case the on-chain price conversion path can't run
 };
 
 // Uniswap V3 FXN/WETH pool on Ethereum mainnet


### PR DESCRIPTION
## What this fixes

After the BOLD fix shipped, the same issue was reported for yUSND. Audited Alchemy's price API for every pool marked \`isStableAsset: true\` and found 5 still broken:

| Symbol | Alchemy | Notes |
|--------|---------|-------|
| sUSDS | missing | yield-bearing, soft-pegged |
| USDe | missing | USD-pegged |
| frxUSD | missing | USD-pegged |
| fxUSD | missing | approximately USD-pegged |
| yUSND | missing | yield-bearing, has \`priceConversion\` to USND but the on-chain call can fail when the active wallet is on a different chain |

These pools render \`-\` instead of dollar amounts for Accepted Funds, Pending Funds and My Funds.

## The change

Add the 5 missing symbols to \`STABLECOIN_FALLBACK_PRICES\` at \`1.0\`. Same pattern as USND, BSCUSD and BOLD already use. The codebase already takes the position elsewhere (\`AllPoolsStats.tsx\`) that an \`isStableAsset\` pool can fall back to a 1:1 USD value when no price data exists.

For yUSND specifically, the existing on-chain price conversion path (yUSND → USND × USND price) still runs first when the wallet client targets Arbitrum. The fallback just keeps the page from showing \`-\` if that path can't run for any reason.

## Test plan

* Open each of the 5 pools and confirm the stat boxes show a USD value.
* Confirm pools with live Alchemy prices (USDC, USDT, DAI, USDS, USD1) still get the live price and aren't overridden.
* Confirm USND, BSCUSD and BOLD still resolve to their fallback prices.