### PR TITLE
feat: add Cloaked Relay and keep configured relayer order

### DIFF
--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -132,7 +132,10 @@ const mainnetChainData: ChainData = {
     decimals: mainnet.nativeCurrency.decimals,
     image: mainnetIcon.src,
     explorerUrl: mainnet.blockExplorers.default.url,
-    relayers: [{ name: 'Fast Relay', url: 'https://fastrelay.xyz' }],
+    relayers: [
+      { name: 'Fast Relay', url: 'https://fastrelay.xyz' },
+      { name: 'Cloaked Relay', url: 'https://api.clkd.xyz' },
+    ],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,
     aspUrl: getAspEndpointForChain(mainnet.id),

--- a/src/providers/ChainProvider.tsx
+++ b/src/providers/ChainProvider.tsx
@@ -229,18 +229,18 @@ export const ChainProvider = ({ children }: Props) => {
 
   const allQueriesAreLoading = useMemo(() => feesQueries.some((q) => q.isLoading), [feesQueries]);
 
+  // Preserve the order configured in chainData so the primary relayer
+  // (Fast Relay) is always shown first in the UI even when an alternative
+  // relayer happens to be cheaper.
   const relayersData: RelayerDataType[] = useMemo(
     () =>
-      feesQueries
-        .map((query, index) => ({
-          name: activeRelayers[index].name,
-          url: activeRelayers[index].url,
-          fees: query.data?.feeBPS,
-          relayerAddress: query.data?.feeReceiverAddress,
-          isSelectable:
-            !query.error && query.data?.feeBPS !== undefined && query.data?.feeReceiverAddress !== undefined,
-        }))
-        .sort((a, b) => (Number(a.fees) ?? Infinity) - (Number(b.fees) ?? Infinity)),
+      feesQueries.map((query, index) => ({
+        name: activeRelayers[index].name,
+        url: activeRelayers[index].url,
+        fees: query.data?.feeBPS,
+        relayerAddress: query.data?.feeReceiverAddress,
+        isSelectable: !query.error && query.data?.feeBPS !== undefined && query.data?.feeReceiverAddress !== undefined,
+      })),
     [feesQueries, activeRelayers],
   );
 


### PR DESCRIPTION
## Summary

Adds Cloaked Relay (`https://api.clkd.xyz`) as a second mainnet relayer alongside Fast Relay, and changes the relayer list so the order configured in `chainData.ts` is preserved in the UI instead of being sorted ascending by fee.

This replaces #189. The relayer URL convention matches Fast Relay (client appends `/relayer/details`, `/relayer/quote`, `/relayer/request`). Cloaked's endpoints are live and return the same response shape.

## Why preserve the configured order

The current code sorted `relayersData` by `feeBPS` ascending, so whichever relayer was cheapest at the moment became the default. Fast Relay should remain the primary regardless of momentary price differences, so this PR removes the sort and lets `chainData` decide the order.

The selection logic in `ChainProvider` is unchanged: it still picks the first `isSelectable` relayer, so if Fast Relay ever goes down the next configured relayer takes over.

## Test plan

- [ ] On mainnet, open the withdraw modal and confirm Fast Relay is selected by default and appears first in the dropdown.
- [ ] Confirm Cloaked Relay appears second in the dropdown with its fee.
- [ ] If Fast Relay returns an error from `/details`, confirm Cloaked Relay is auto-selected.