### PR TITLE
Release v2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display the selected relayer name as the fee collector in the withdrawal review modal instead of always showing `0xBow`
 - Fixed a race in the relayer auto-select effect that caused Cloaked Relay to win the default slot when its `/details` endpoint responded faster than Fast Relay's
 - Fall back to an ASP-derived per-token price when Alchemy doesn't return one, so withdrawal review modal and other surfaces stop showing `$0.00 USD` (and yield-bearing tokens like sUSDS show their actual price instead of a flat $1)
+- Coerce Alchemy price values to a number (the API returns quoted strings) so the review modal no longer silently throws and shows `$0.00`
+- Reset the quote, fee commitment and countdown when the user switches relayer in the withdraw form, so reopening the Review modal doesn't show stale data from the previous relayer
 
 ## [2.14.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Restored the relayer dropdown so users can pick between Fast Relay and Cloaked Relay (Fast Relay stays first)
+- Display the selected relayer name as the fee collector in the withdrawal review modal instead of always showing `0xBow`
 
 ## [2.14.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restored the relayer dropdown so users can pick between Fast Relay and Cloaked Relay (Fast Relay stays first)
 - Display the selected relayer name as the fee collector in the withdrawal review modal instead of always showing `0xBow`
+- Fixed a race in the relayer auto-select effect that caused Cloaked Relay to win the default slot when its `/details` endpoint responded faster than Fast Relay's
+- Fall back to an ASP-derived per-token price when Alchemy doesn't return one, so withdrawal review modal and other surfaces stop showing `$0.00 USD` (and yield-bearing tokens like sUSDS show their actual price instead of a flat $1)
 
 ## [2.14.0] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.1] - 2026-05-15
+
+### Fixed
+
+- Restored the relayer dropdown so users can pick between Fast Relay and Cloaked Relay (Fast Relay stays first)
+
 ## [2.2.0] - 2026-03-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.14.1",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -162,7 +162,8 @@ export const DataSection = () => {
   const feesCollectorAddress = isDeposit
     ? selectedPoolInfo.entryPointAddress
     : currentSelectedRelayerData?.relayerAddress;
-  const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress)})`;
+  const feesCollectorName = isDeposit ? '0xBow' : currentSelectedRelayerData?.name || 'Relayer';
+  const feesCollector = `${feesCollectorName} (${truncateAddress(feesCollectorAddress)})`;
 
   // Use alternative token symbol if selected
   const displaySymbol = selectedAlternativeToken && isDeposit ? selectedAlternativeToken.tokenSymbol : symbol;

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -250,7 +250,7 @@ export const DataSection = () => {
 
         <Row>
           <Label variant='body2'>To:</Label>
-          <Value component='div' variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AddressValue>
             {ensAvatar && <Avatar src={ensAvatar} sx={{ width: 20, height: 20 }} />}
             <Tooltip title={toAddress} placement='top'>
               <span>
@@ -258,7 +258,7 @@ export const DataSection = () => {
                 {!toAddress && 'New Pool Account'}
               </span>
             </Tooltip>
-          </Value>
+          </AddressValue>
         </Row>
       </Stack>
       {actionType !== EventType.EXIT && (
@@ -394,6 +394,21 @@ const Label = styled(Typography)(({ theme }) => ({
 
 const Value = styled(Label)(() => ({
   fontWeight: 400,
+}));
+
+const AddressValue = styled('div')(({ theme }) => ({
+  color: theme.palette.grey[500],
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  fontSize: '1.6rem',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: '150%',
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: theme.typography.body2.fontSize,
+  },
 }));
 
 const QuoteTimer = styled(Value)(({ theme }) => ({

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -96,6 +96,7 @@ export const DataSection = () => {
     amountBN,
     assetAddress: selectedPoolInfo?.assetAddress,
     recipient: target,
+    relayerUrl: currentSelectedRelayerData?.url,
     isValidAmount: amountBN > 0n,
     isRecipientAddressValid: !!target,
     isRelayerSelected: !!currentSelectedRelayerData?.relayerAddress,
@@ -249,7 +250,7 @@ export const DataSection = () => {
 
         <Row>
           <Label variant='body2'>To:</Label>
-          <Value variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Value component='div' variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             {ensAvatar && <Avatar src={ensAvatar} sx={{ width: 20, height: 20 }} />}
             <Tooltip title={toAddress} placement='top'>
               <span>

--- a/src/containers/Modals/Review/Review.tsx
+++ b/src/containers/Modals/Review/Review.tsx
@@ -52,6 +52,7 @@ export const ReviewModal = () => {
     amountBN,
     assetAddress: selectedPoolInfo?.assetAddress,
     recipient: target,
+    relayerUrl: currentSelectedRelayerData?.url,
     isValidAmount: amountBN > 0n,
     isRecipientAddressValid: !!target,
     isRelayerSelected: !!currentSelectedRelayerData?.relayerAddress,

--- a/src/containers/Modals/Withdraw/RelayerSelectorSection.tsx
+++ b/src/containers/Modals/Withdraw/RelayerSelectorSection.tsx
@@ -1,6 +1,16 @@
 'use client';
 
-import { CircularProgress, Stack, styled, Typography, SelectChangeEvent } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  FormControl,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  styled,
+  Typography,
+} from '@mui/material';
 
 type RelayerData = {
   name: string;
@@ -22,6 +32,8 @@ interface RelayerSelectorSectionProps {
 
 export const RelayerSelectorSection = ({
   selectedRelayer,
+  relayersData,
+  handleRelayerChange,
   isQuoteLoading,
   quoteError,
   feeText,
@@ -30,7 +42,36 @@ export const RelayerSelectorSection = ({
 }: RelayerSelectorSectionProps) => {
   return (
     <Stack gap='1.2rem' width='100%' alignItems='center'>
-      <RelayerLabel>{selectedRelayer?.name || 'Fast Relay'}</RelayerLabel>
+      <FormControl fullWidth>
+        <RelayerSelect
+          id='relayer-select'
+          labelId='relayer-select-label'
+          value={selectedRelayer?.url ?? ''}
+          onChange={handleRelayerChange}
+          renderValue={() => selectedRelayer?.name ?? 'Select Relayer'}
+          displayEmpty
+        >
+          {relayersData.map(({ name, url, fees, isSelectable }) => (
+            <RelayMenuItem key={url} value={url} disabled={!isSelectable}>
+              <Stack direction='row' justifyContent='space-between' alignItems='center' width='100%'>
+                <Box>
+                  <Typography variant='body2'>{name}</Typography>
+                  {fees !== undefined && (
+                    <Typography variant='caption' color='textSecondary'>
+                      Base Fee: {Number(fees) / 100}%
+                    </Typography>
+                  )}
+                </Box>
+                {!isSelectable && (
+                  <Typography variant='caption' color='error'>
+                    Unavailable
+                  </Typography>
+                )}
+              </Stack>
+            </RelayMenuItem>
+          ))}
+        </RelayerSelect>
+      </FormControl>
 
       {/* Fee Details */}
       <Stack direction='column' alignItems='flex-start' gap={0.5} width='100%'>
@@ -53,12 +94,23 @@ export const RelayerSelectorSection = ({
   );
 };
 
-const RelayerLabel = styled(Typography)(({ theme }) => ({
-  width: '100%',
-  padding: '16px 14px',
-  border: `1px solid ${theme.palette.grey[400]}`,
-  borderRadius: '4px',
-  fontSize: '16px',
-  fontWeight: 500,
-  color: theme.palette.text.primary,
+const RelayerSelect = styled(Select)(({ theme }) => ({
+  '& .MuiSelect-select': {
+    padding: '16px 14px',
+    fontSize: '16px',
+    fontWeight: 500,
+    color: theme.palette.text.primary,
+  },
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: theme.palette.grey[400],
+  },
 }));
+
+const RelayMenuItem = styled(MenuItem)({
+  '&.Mui-disabled': {
+    opacity: 0.5,
+    span: {
+      fontWeight: 700,
+    },
+  },
+});

--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -57,9 +57,10 @@ export const WithdrawForm = () => {
     setChainId,
   } = useChainContext();
 
-  const { amount, setAmount, target, setTarget, poolAccount, setPoolAccount } = usePoolAccountsContext();
+  const { amount, setAmount, target, setTarget, poolAccount, setPoolAccount, setFeeCommitment, setFeeBPSForWithdraw } =
+    usePoolAccountsContext();
   const { poolAccounts } = useAccountContext();
-  const { setExtraGas, requestQuote } = useQuoteContext();
+  const { setExtraGas, requestQuote, resetQuote } = useQuoteContext();
   const { switchChainAsync } = useSwitchChain();
 
   const [tokenSelectorAnchor, setTokenSelectorAnchor] = useState<HTMLElement | null>(null);
@@ -125,7 +126,7 @@ export const WithdrawForm = () => {
 
   // Resolved address display component
   const ResolvedAddressDisplay = () => (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+    <Box component='span' sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
       <span>Resolved to: {truncateAddress(target)}</span>
       <Tooltip title={`${target} (Click to copy)`}>
         <Box
@@ -448,6 +449,11 @@ export const WithdrawForm = () => {
   const handleRelayerChange = (e: SelectChangeEvent<unknown>) => {
     const newRelayerUrl = e.target.value as string;
     const newRelayer = relayersData.find((r) => r.url === newRelayerUrl);
+    if (newRelayerUrl !== selectedRelayer?.url) {
+      resetQuote();
+      setFeeCommitment(null);
+      setFeeBPSForWithdraw(0n);
+    }
     setSelectedRelayer(newRelayer ? { name: newRelayer.name, url: newRelayer.url } : undefined);
   };
 

--- a/src/contexts/QuoteContext.tsx
+++ b/src/contexts/QuoteContext.tsx
@@ -13,6 +13,7 @@ interface QuoteState {
   isExpired: boolean;
   extraGas: boolean;
   quotedAmount: string | null; // The amount used when the quote was requested
+  quotedRelayerUrl: string | null; // The relayer that produced the quote
   pendingQuoteRequest: boolean; // Flag to trigger quote request when Review screen opens
 }
 
@@ -26,6 +27,7 @@ interface QuoteContextType {
     relayTxCostETH: string | null,
     countdown: number,
     quotedAmount: string,
+    quotedRelayerUrl: string,
   ) => void;
   updateCountdown: (countdown: number) => void;
   resetQuote: () => void;
@@ -48,6 +50,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
     isExpired: false,
     extraGas: false,
     quotedAmount: null,
+    quotedRelayerUrl: null,
     pendingQuoteRequest: false,
   });
 
@@ -60,6 +63,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
       relayTxCostETH: string | null,
       countdown: number,
       quotedAmount: string,
+      quotedRelayerUrl: string,
     ) => {
       setQuoteState((prev) => ({
         quoteCommitment: commitment,
@@ -71,6 +75,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
         isExpired: countdown <= 0, // Mark as expired immediately if countdown is already 0 (e.g., clock skew)
         extraGas: prev.extraGas, // Preserve current extraGas setting
         quotedAmount,
+        quotedRelayerUrl,
         pendingQuoteRequest: false, // Clear pending request when quote is set
       }));
     },
@@ -96,6 +101,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
       isExpired: false,
       extraGas: prev.extraGas, // Preserve extraGas setting when resetting quote
       quotedAmount: null,
+      quotedRelayerUrl: null,
       pendingQuoteRequest: prev.pendingQuoteRequest, // Preserve pending request state
     }));
   }, []);

--- a/src/hooks/useRequestQuote.ts
+++ b/src/hooks/useRequestQuote.ts
@@ -17,6 +17,7 @@ interface UseRequestQuoteParams {
   amountBN: bigint;
   assetAddress: Address | undefined;
   recipient: Address | '';
+  relayerUrl: string | undefined;
 
   isValidAmount: boolean;
   isRecipientAddressValid: boolean;
@@ -49,6 +50,7 @@ export const useRequestQuote = ({
   amountBN,
   assetAddress,
   recipient,
+  relayerUrl,
   isValidAmount,
   isRecipientAddressValid,
   isRelayerSelected,
@@ -78,14 +80,24 @@ export const useRequestQuote = ({
       !!recipient &&
       isRecipientAddressValid &&
       isRelayerSelected &&
+      !!relayerUrl &&
       !!assetAddress &&
       chainId !== undefined &&
       amountBN > 0n
     );
-  }, [isValidAmount, recipient, isRecipientAddressValid, isRelayerSelected, assetAddress, chainId, amountBN]);
+  }, [
+    isValidAmount,
+    recipient,
+    isRecipientAddressValid,
+    isRelayerSelected,
+    relayerUrl,
+    assetAddress,
+    chainId,
+    amountBN,
+  ]);
 
   const executeFetchAndSetQuote = useCallback(async () => {
-    if (!canRequestQuote || !chainId || !assetAddress || !recipient || isFetchingRef.current) {
+    if (!canRequestQuote || !chainId || !assetAddress || !recipient || !relayerUrl || isFetchingRef.current) {
       return;
     }
 
@@ -117,6 +129,7 @@ export const useRequestQuote = ({
         newQuoteData.detail?.relayTxCost?.eth || null,
         remainingTime,
         requestedAmount,
+        relayerUrl,
       );
     } catch (err) {
       // If extraGas was requested but the relayer doesn't support it for this chain,
@@ -144,6 +157,7 @@ export const useRequestQuote = ({
             retryData.detail?.relayTxCost?.eth || null,
             remainingTime,
             requestedAmount,
+            relayerUrl,
           );
           return;
         } catch (retryErr) {
@@ -168,6 +182,7 @@ export const useRequestQuote = ({
     amountBN,
     assetAddress,
     recipient,
+    relayerUrl,
     quoteState.extraGas,
     getQuote,
     addNotification,
@@ -251,6 +266,7 @@ export const useRequestQuote = ({
       quoteState.quoteCommitment &&
       quoteState.countdown > 0 &&
       !quoteState.isExpired &&
+      quoteState.quotedRelayerUrl === relayerUrl &&
       currentQuoteId &&
       currentQuoteId !== currentQuoteIdRef.current &&
       !globalTimerInstanceActive
@@ -258,16 +274,25 @@ export const useRequestQuote = ({
       startTimer(currentQuoteId, quoteState.countdown);
     }
 
-    if (!quoteState.quoteCommitment) {
+    if (!quoteState.quoteCommitment || quoteState.quotedRelayerUrl !== relayerUrl) {
       stopTimer();
     }
 
     return stopTimer;
-  }, [quoteState.quoteCommitment?.signedRelayerCommitment, quoteState.isExpired]);
+  }, [
+    quoteState.quoteCommitment?.signedRelayerCommitment,
+    quoteState.isExpired,
+    quoteState.quotedRelayerUrl,
+    relayerUrl,
+  ]);
 
   const isQuoteValid = useMemo(
-    () => quoteState.quoteCommitment !== null && quoteState.countdown > 0 && !quoteState.isExpired,
-    [quoteState.quoteCommitment, quoteState.countdown, quoteState.isExpired],
+    () =>
+      quoteState.quoteCommitment !== null &&
+      quoteState.countdown > 0 &&
+      !quoteState.isExpired &&
+      quoteState.quotedRelayerUrl === relayerUrl,
+    [quoteState.quoteCommitment, quoteState.countdown, quoteState.isExpired, quoteState.quotedRelayerUrl, relayerUrl],
   );
 
   const requestNewQuote = useCallback(async () => {

--- a/src/providers/ChainProvider.tsx
+++ b/src/providers/ChainProvider.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { createContext, useEffect, useMemo, useState, useRef, useCallback } from 'react';
-import { useQueries } from '@tanstack/react-query';
-import { parseEther } from 'viem';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { formatUnits, parseEther } from 'viem';
 import { useAccount, useBalance, usePublicClient } from 'wagmi';
 import { ChainData, chainData, allPoolsChainData, ChainAssets, whitelistedChains, PoolInfo, getConfig } from '~/config';
+import { getAspEndpointForChain } from '~/config/env';
 import { useNotifications } from '~/hooks';
-import { fetchTokenPrice, relayerClient } from '~/utils';
+import { aspClient, fetchTokenPrice, relayerClient } from '~/utils';
 
 type RelayerDataType = {
   name: string;
@@ -214,6 +215,45 @@ export const ChainProvider = ({ children }: Props) => {
     doFetchNativeAssetPrice();
   }, [doFetchPrice, doFetchNativeAssetPrice]);
 
+  // Pool stats include both the token amount and the USD value of accepted
+  // deposits, which lets us derive a per-token price as a fallback when
+  // Alchemy's price API doesn't list the token or returns 0. This also gives
+  // accurate prices for yield-bearing tokens (e.g. sUSDS trades above $1).
+  const { data: poolStatsData } = useQuery({
+    queryKey: ['pool_stats', chainId],
+    queryFn: () => aspClient.fetchPoolStats(getAspEndpointForChain(chainId), chainId),
+    enabled: !!chainId,
+    refetchInterval: 120000,
+    staleTime: 60000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  const derivedPriceFromStats = useMemo(() => {
+    if (!poolStatsData?.pools || !selectedPoolInfo?.scope) return null;
+    const scopeStr = selectedPoolInfo.scope.toString();
+    const ps = poolStatsData.pools.find((p) => p.scope === scopeStr);
+    const usdStr = ps?.acceptedDepositsValueUsd ?? ps?.totalInPoolValueUsd;
+    const tokensStr = ps?.acceptedDepositsValue ?? ps?.totalInPoolValue;
+    if (!usdStr || !tokensStr) return null;
+    const usd = parseFloat(String(usdStr).replace(/,/g, ''));
+    if (!Number.isFinite(usd) || usd <= 0) return null;
+    let tokens: number;
+    try {
+      tokens = Number(formatUnits(BigInt(tokensStr), selectedPoolInfo.assetDecimals || 18));
+    } catch {
+      return null;
+    }
+    if (tokens <= 0) return null;
+    return usd / tokens;
+  }, [poolStatsData, selectedPoolInfo]);
+
+  // Live token price from Alchemy/conversion if available, otherwise fall
+  // back to the price derived from the ASP pool stats. Exposed to all
+  // consumers via context.price so the withdraw review modal, fee breakdown,
+  // pool page and anywhere else stay consistent.
+  const effectivePrice = price ?? derivedPriceFromStats;
+
   const feesQueries = useQueries({
     queries: activeRelayers.map((relayer) => ({
       queryKey: ['relayerFees', relayer.url, chainId, selectedPoolInfo?.assetAddress],
@@ -260,8 +300,16 @@ export const ChainProvider = ({ children }: Props) => {
     }
   }, [hasSomeRelayerAvailable, allQueriesAreLoading, addNotification]);
 
-  // Effect to ensure the relayer selection is always valid
+  // Effect to ensure the relayer selection is always valid.
+  //
+  // Wait for every relayer's /details query to finish before doing the
+  // auto-select. Otherwise the first relayer to respond (e.g. a faster
+  // secondary relayer) wins the default slot and the configured primary
+  // (Fast Relay) never gets re-selected once it loads, because the effect
+  // sees a valid current selection and bails out.
   useEffect(() => {
+    if (allQueriesAreLoading) return;
+
     const firstAvailable = relayersData.find((r) => r.isSelectable);
     const isCurrentSelectedStillValid = selectedRelayer
       ? relayersData.some((r) => r.url === selectedRelayer.url && r.isSelectable)
@@ -280,7 +328,7 @@ export const ChainProvider = ({ children }: Props) => {
         handleSetSelectedRelayer(undefined);
       }
     }
-  }, [relayersData, selectedRelayer, handleSetSelectedRelayer]);
+  }, [allQueriesAreLoading, relayersData, selectedRelayer, handleSetSelectedRelayer]);
 
   const contextValue = useMemo(
     () => ({
@@ -289,7 +337,7 @@ export const ChainProvider = ({ children }: Props) => {
       balanceBN,
       balanceInPoolBN,
       setBalanceInPool: handleSetBalanceInPool,
-      price,
+      price: effectivePrice,
       nativeAssetPrice,
       refetchPrice,
       maxDeposit: selectedPoolInfo?.maxDeposit.toString() ?? '0',
@@ -313,7 +361,7 @@ export const ChainProvider = ({ children }: Props) => {
       balanceBN,
       balanceInPoolBN,
       handleSetBalanceInPool,
-      price,
+      effectivePrice,
       nativeAssetPrice,
       refetchPrice,
       selectedPoolInfo,

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -135,7 +135,9 @@ export const fetchTokenPrice = async (
       // Get the price of the underlying asset
       const underlyingResponse = await fetch(`${url}symbols=${underlyingAsset}`, options);
       const underlyingJson = await underlyingResponse.json();
-      let underlyingPrice = underlyingJson.data?.[0]?.prices?.[0]?.value;
+      const rawUnderlyingPrice = underlyingJson.data?.[0]?.prices?.[0]?.value;
+      let underlyingPrice =
+        rawUnderlyingPrice != null && Number.isFinite(Number(rawUnderlyingPrice)) ? Number(rawUnderlyingPrice) : 0;
 
       // Use fallback price for stablecoins not supported by Alchemy
       if (!underlyingPrice && STABLECOIN_FALLBACK_PRICES[underlyingAsset]) {
@@ -159,9 +161,16 @@ export const fetchTokenPrice = async (
   // Standard price fetch from Alchemy
   const response = await fetch(`${url}symbols=${symbol}`, options);
   const json = await response.json();
-  const value = json.data?.[0]?.prices?.[0]?.value;
-  if (!value && STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
-    return STABLECOIN_FALLBACK_PRICES[symbol];
+  // Alchemy returns price values as JSON strings (e.g. "0.9998"). Coerce to a
+  // number so callers that expect a number (e.g. `getUsdBalance` calls
+  // `price.toFixed`) don't silently throw and return $0.
+  const rawValue = json.data?.[0]?.prices?.[0]?.value;
+  const numericValue = rawValue != null ? Number(rawValue) : NaN;
+  if (!Number.isFinite(numericValue) || numericValue === 0) {
+    if (STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
+      return STABLECOIN_FALLBACK_PRICES[symbol];
+    }
+    return 0;
   }
-  return value || 0;
+  return numericValue;
 };


### PR DESCRIPTION
## Release v2.14.1

### Fixed

- Restored the relayer dropdown so users can pick between Fast Relay and Cloaked Relay (Fast Relay stays first)
- Display the selected relayer name as the fee collector in the withdrawal review modal instead of always showing `0xBow` (also fixes the `OxBow` typo)
- Fixed a race in the relayer auto-select effect that caused Cloaked Relay to win the default slot when its `/details` endpoint responded faster than Fast Relay's
- Fall back to an ASP-derived per-token price when Alchemy doesn't return one, so the withdrawal review modal and other surfaces stop showing `$0.00 USD` (and yield-bearing tokens like sUSDS show their actual price instead of a flat $1)
- Coerce Alchemy price values to a number (the API returns quoted strings) so `getUsdBalance` no longer silently throws on `price.toFixed` and returns `'0'`
- Reset the quote, fee commitment and countdown when the user switches relayer in the withdraw form, so reopening the Review modal doesn't show stale data from the previous relayer

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.