### PR TITLE
fix(withdraw): show selected relayer name as fee collector

### DIFF
--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -162,7 +162,8 @@ export const DataSection = () => {
   const feesCollectorAddress = isDeposit
     ? selectedPoolInfo.entryPointAddress
     : currentSelectedRelayerData?.relayerAddress;
-  const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress)})`;
+  const feesCollectorName = isDeposit ? '0xBow' : currentSelectedRelayerData?.name || 'Relayer';
+  const feesCollector = `${feesCollectorName} (${truncateAddress(feesCollectorAddress)})`;
 
   // Use alternative token symbol if selected
   const displaySymbol = selectedAlternativeToken && isDeposit ? selectedAlternativeToken.tokenSymbol : symbol;


### PR DESCRIPTION
## What this fixes

The review modal labels the fees collector as "OxBow" for every transaction, even on withdrawals where the actual fee collector is the selected relayer (Fast Relay or Cloaked Relay), not 0xBow. Looks confusing because the displayed address is the relayer's address, but the label says 0xBow.

Also fixes a typo: `OxBow` (capital O) → `0xBow` (zero).

## The change

Single line, in `src/containers/Modals/Review/DataSection.tsx`:

```diff
- const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress)})`;
+ const feesCollectorName = isDeposit ? '0xBow' : currentSelectedRelayerData?.name || 'Relayer';
+ const feesCollector = `${feesCollectorName} (${truncateAddress(feesCollectorAddress)})`;
```

On deposits the address is `selectedPoolInfo.entryPointAddress` (the 0xBow entry point), so the label stays `0xBow`. On withdrawals the address is `currentSelectedRelayerData.relayerAddress`, so the label uses the relayer's display name with `'Relayer'` as a safe fallback.

## Provenance

Cherry-picked from a contributor's fork branch (`0xmatthewb/privacy-pools-website#cloaked`, commit `2b60690`). Only this one commit was picked — the rest of that branch is release/merge noise.

## Test plan

- [ ] Open the withdraw review modal — fee collector reads `Fast Relay (0x...)` or `Cloaked Relay (0x...)` depending on the selected relayer
- [ ] Open the deposit review modal — fee collector still reads `0xBow (0x...)`
- [ ] Switch relayers in the dropdown and reopen review — the label updates