### PR TITLE
fix(withdraw): show selected relayer name as fee collector

### DIFF
--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -162,7 +162,8 @@ export const DataSection = () => {
   const feesCollectorAddress = isDeposit
     ? selectedPoolInfo.entryPointAddress
     : currentSelectedRelayerData?.relayerAddress;
-  const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress)})`;
+  const feesCollectorName = isDeposit ? '0xBow' : currentSelectedRelayerData?.name || 'Relayer';
+  const feesCollector = `${feesCollectorName} (${truncateAddress(feesCollectorAddress)})`;
 
   // Use alternative token symbol if selected
   const displaySymbol = selectedAlternativeToken && isDeposit ? selectedAlternativeToken.tokenSymbol : symbol;


### PR DESCRIPTION
## What this fixes

The review modal labels the fees collector as `OxBow` for every transaction, even on withdrawals where the actual fee collector is the selected relayer (Fast Relay or Cloaked Relay). The displayed address is the relayer's address but the label said `OxBow`.

Also fixes the `OxBow` (capital O) → `0xBow` (zero) typo.

## The change

Single line, in `src/containers/Modals/Review/DataSection.tsx`:

```diff
- const feesCollector = `OxBow (${truncateAddress(feesCollectorAddress)})`;
+ const feesCollectorName = isDeposit ? '0xBow' : currentSelectedRelayerData?.name || 'Relayer';
+ const feesCollector = `${feesCollectorName} (${truncateAddress(feesCollectorAddress)})`;
```

Deposits still read `0xBow (0x...)` (since the address is the entry point). Withdrawals now read `Fast Relay (0x...)` or `Cloaked Relay (0x...)` matching the actual relayer.

## Provenance

Cherry-picked from contributor branch `0xmatthewb/privacy-pools-website#cloaked` (commit `2b60690`). Author preserved on the commit.

> This same change is also cherry-picked into the v2.14.1 release PR #204 so it ships now. This PR keeps it on `dev` so the next release branch doesn't regress.

## Test plan

- [ ] Withdraw review modal — fee collector reads `Fast Relay (0x...)` or `Cloaked Relay (0x...)`
- [ ] Deposit review modal — fee collector still reads `0xBow (0x...)`
- [ ] Switching the relayer in the dropdown updates the label