### PR TITLE
fix: keep Fast Relay as default and fall back to ASP-derived USD price

### DIFF
--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -249,7 +249,7 @@ export const DataSection = () => {
 
         <Row>
           <Label variant='body2'>To:</Label>
-          <Value component='div' variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AddressValue>
             {ensAvatar && <Avatar src={ensAvatar} sx={{ width: 20, height: 20 }} />}
             <Tooltip title={toAddress} placement='top'>
               <span>
@@ -257,7 +257,7 @@ export const DataSection = () => {
                 {!toAddress && 'New Pool Account'}
               </span>
             </Tooltip>
-          </Value>
+          </AddressValue>
         </Row>
       </Stack>
       {actionType !== EventType.EXIT && (
@@ -393,6 +393,21 @@ const Label = styled(Typography)(({ theme }) => ({
 
 const Value = styled(Label)(() => ({
   fontWeight: 400,
+}));
+
+const AddressValue = styled('div')(({ theme }) => ({
+  color: theme.palette.grey[500],
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  fontSize: '1.6rem',
+  fontStyle: 'normal',
+  fontWeight: 400,
+  lineHeight: '150%',
+
+  [theme.breakpoints.down('sm')]: {
+    fontSize: theme.typography.body2.fontSize,
+  },
 }));
 
 const QuoteTimer = styled(Value)(({ theme }) => ({

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -96,6 +96,7 @@ export const DataSection = () => {
     amountBN,
     assetAddress: selectedPoolInfo?.assetAddress,
     recipient: target,
+    relayerUrl: currentSelectedRelayerData?.url,
     isValidAmount: amountBN > 0n,
     isRecipientAddressValid: !!target,
     isRelayerSelected: !!currentSelectedRelayerData?.relayerAddress,
@@ -248,7 +249,7 @@ export const DataSection = () => {
 
         <Row>
           <Label variant='body2'>To:</Label>
-          <Value variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Value component='div' variant='body2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             {ensAvatar && <Avatar src={ensAvatar} sx={{ width: 20, height: 20 }} />}
             <Tooltip title={toAddress} placement='top'>
               <span>

--- a/src/containers/Modals/Review/Review.tsx
+++ b/src/containers/Modals/Review/Review.tsx
@@ -52,6 +52,7 @@ export const ReviewModal = () => {
     amountBN,
     assetAddress: selectedPoolInfo?.assetAddress,
     recipient: target,
+    relayerUrl: currentSelectedRelayerData?.url,
     isValidAmount: amountBN > 0n,
     isRecipientAddressValid: !!target,
     isRelayerSelected: !!currentSelectedRelayerData?.relayerAddress,

--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -57,9 +57,10 @@ export const WithdrawForm = () => {
     setChainId,
   } = useChainContext();
 
-  const { amount, setAmount, target, setTarget, poolAccount, setPoolAccount } = usePoolAccountsContext();
+  const { amount, setAmount, target, setTarget, poolAccount, setPoolAccount, setFeeCommitment, setFeeBPSForWithdraw } =
+    usePoolAccountsContext();
   const { poolAccounts } = useAccountContext();
-  const { setExtraGas, requestQuote } = useQuoteContext();
+  const { setExtraGas, requestQuote, resetQuote } = useQuoteContext();
   const { switchChainAsync } = useSwitchChain();
 
   const [tokenSelectorAnchor, setTokenSelectorAnchor] = useState<HTMLElement | null>(null);
@@ -125,7 +126,7 @@ export const WithdrawForm = () => {
 
   // Resolved address display component
   const ResolvedAddressDisplay = () => (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+    <Box component='span' sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
       <span>Resolved to: {truncateAddress(target)}</span>
       <Tooltip title={`${target} (Click to copy)`}>
         <Box
@@ -448,6 +449,11 @@ export const WithdrawForm = () => {
   const handleRelayerChange = (e: SelectChangeEvent<unknown>) => {
     const newRelayerUrl = e.target.value as string;
     const newRelayer = relayersData.find((r) => r.url === newRelayerUrl);
+    if (newRelayerUrl !== selectedRelayer?.url) {
+      resetQuote();
+      setFeeCommitment(null);
+      setFeeBPSForWithdraw(0n);
+    }
     setSelectedRelayer(newRelayer ? { name: newRelayer.name, url: newRelayer.url } : undefined);
   };
 

--- a/src/contexts/QuoteContext.tsx
+++ b/src/contexts/QuoteContext.tsx
@@ -13,6 +13,7 @@ interface QuoteState {
   isExpired: boolean;
   extraGas: boolean;
   quotedAmount: string | null; // The amount used when the quote was requested
+  quotedRelayerUrl: string | null; // The relayer that produced the quote
   pendingQuoteRequest: boolean; // Flag to trigger quote request when Review screen opens
 }
 
@@ -26,6 +27,7 @@ interface QuoteContextType {
     relayTxCostETH: string | null,
     countdown: number,
     quotedAmount: string,
+    quotedRelayerUrl: string,
   ) => void;
   updateCountdown: (countdown: number) => void;
   resetQuote: () => void;
@@ -48,6 +50,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
     isExpired: false,
     extraGas: false,
     quotedAmount: null,
+    quotedRelayerUrl: null,
     pendingQuoteRequest: false,
   });
 
@@ -60,6 +63,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
       relayTxCostETH: string | null,
       countdown: number,
       quotedAmount: string,
+      quotedRelayerUrl: string,
     ) => {
       setQuoteState((prev) => ({
         quoteCommitment: commitment,
@@ -71,6 +75,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
         isExpired: countdown <= 0, // Mark as expired immediately if countdown is already 0 (e.g., clock skew)
         extraGas: prev.extraGas, // Preserve current extraGas setting
         quotedAmount,
+        quotedRelayerUrl,
         pendingQuoteRequest: false, // Clear pending request when quote is set
       }));
     },
@@ -96,6 +101,7 @@ export function QuoteProvider({ children }: { children: ReactNode }) {
       isExpired: false,
       extraGas: prev.extraGas, // Preserve extraGas setting when resetting quote
       quotedAmount: null,
+      quotedRelayerUrl: null,
       pendingQuoteRequest: prev.pendingQuoteRequest, // Preserve pending request state
     }));
   }, []);

--- a/src/hooks/useRequestQuote.ts
+++ b/src/hooks/useRequestQuote.ts
@@ -17,6 +17,7 @@ interface UseRequestQuoteParams {
   amountBN: bigint;
   assetAddress: Address | undefined;
   recipient: Address | '';
+  relayerUrl: string | undefined;
 
   isValidAmount: boolean;
   isRecipientAddressValid: boolean;
@@ -49,6 +50,7 @@ export const useRequestQuote = ({
   amountBN,
   assetAddress,
   recipient,
+  relayerUrl,
   isValidAmount,
   isRecipientAddressValid,
   isRelayerSelected,
@@ -78,14 +80,24 @@ export const useRequestQuote = ({
       !!recipient &&
       isRecipientAddressValid &&
       isRelayerSelected &&
+      !!relayerUrl &&
       !!assetAddress &&
       chainId !== undefined &&
       amountBN > 0n
     );
-  }, [isValidAmount, recipient, isRecipientAddressValid, isRelayerSelected, assetAddress, chainId, amountBN]);
+  }, [
+    isValidAmount,
+    recipient,
+    isRecipientAddressValid,
+    isRelayerSelected,
+    relayerUrl,
+    assetAddress,
+    chainId,
+    amountBN,
+  ]);
 
   const executeFetchAndSetQuote = useCallback(async () => {
-    if (!canRequestQuote || !chainId || !assetAddress || !recipient || isFetchingRef.current) {
+    if (!canRequestQuote || !chainId || !assetAddress || !recipient || !relayerUrl || isFetchingRef.current) {
       return;
     }
 
@@ -117,6 +129,7 @@ export const useRequestQuote = ({
         newQuoteData.detail?.relayTxCost?.eth || null,
         remainingTime,
         requestedAmount,
+        relayerUrl,
       );
     } catch (err) {
       // If extraGas was requested but the relayer doesn't support it for this chain,
@@ -144,6 +157,7 @@ export const useRequestQuote = ({
             retryData.detail?.relayTxCost?.eth || null,
             remainingTime,
             requestedAmount,
+            relayerUrl,
           );
           return;
         } catch (retryErr) {
@@ -168,6 +182,7 @@ export const useRequestQuote = ({
     amountBN,
     assetAddress,
     recipient,
+    relayerUrl,
     quoteState.extraGas,
     getQuote,
     addNotification,
@@ -251,6 +266,7 @@ export const useRequestQuote = ({
       quoteState.quoteCommitment &&
       quoteState.countdown > 0 &&
       !quoteState.isExpired &&
+      quoteState.quotedRelayerUrl === relayerUrl &&
       currentQuoteId &&
       currentQuoteId !== currentQuoteIdRef.current &&
       !globalTimerInstanceActive
@@ -258,16 +274,25 @@ export const useRequestQuote = ({
       startTimer(currentQuoteId, quoteState.countdown);
     }
 
-    if (!quoteState.quoteCommitment) {
+    if (!quoteState.quoteCommitment || quoteState.quotedRelayerUrl !== relayerUrl) {
       stopTimer();
     }
 
     return stopTimer;
-  }, [quoteState.quoteCommitment?.signedRelayerCommitment, quoteState.isExpired]);
+  }, [
+    quoteState.quoteCommitment?.signedRelayerCommitment,
+    quoteState.isExpired,
+    quoteState.quotedRelayerUrl,
+    relayerUrl,
+  ]);
 
   const isQuoteValid = useMemo(
-    () => quoteState.quoteCommitment !== null && quoteState.countdown > 0 && !quoteState.isExpired,
-    [quoteState.quoteCommitment, quoteState.countdown, quoteState.isExpired],
+    () =>
+      quoteState.quoteCommitment !== null &&
+      quoteState.countdown > 0 &&
+      !quoteState.isExpired &&
+      quoteState.quotedRelayerUrl === relayerUrl,
+    [quoteState.quoteCommitment, quoteState.countdown, quoteState.isExpired, quoteState.quotedRelayerUrl, relayerUrl],
   );
 
   const requestNewQuote = useCallback(async () => {

--- a/src/providers/ChainProvider.tsx
+++ b/src/providers/ChainProvider.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { createContext, useEffect, useMemo, useState, useRef, useCallback } from 'react';
-import { useQueries } from '@tanstack/react-query';
-import { parseEther } from 'viem';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { formatUnits, parseEther } from 'viem';
 import { useAccount, useBalance, usePublicClient } from 'wagmi';
 import { ChainData, chainData, allPoolsChainData, ChainAssets, whitelistedChains, PoolInfo, getConfig } from '~/config';
+import { getAspEndpointForChain } from '~/config/env';
 import { useNotifications } from '~/hooks';
-import { fetchTokenPrice, relayerClient } from '~/utils';
+import { aspClient, fetchTokenPrice, relayerClient } from '~/utils';
 
 type RelayerDataType = {
   name: string;
@@ -214,6 +215,45 @@ export const ChainProvider = ({ children }: Props) => {
     doFetchNativeAssetPrice();
   }, [doFetchPrice, doFetchNativeAssetPrice]);
 
+  // Pool stats include both the token amount and the USD value of accepted
+  // deposits, which lets us derive a per-token price as a fallback when
+  // Alchemy's price API doesn't list the token or returns 0. This also gives
+  // accurate prices for yield-bearing tokens (e.g. sUSDS trades above $1).
+  const { data: poolStatsData } = useQuery({
+    queryKey: ['pool_stats', chainId],
+    queryFn: () => aspClient.fetchPoolStats(getAspEndpointForChain(chainId), chainId),
+    enabled: !!chainId,
+    refetchInterval: 120000,
+    staleTime: 60000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  const derivedPriceFromStats = useMemo(() => {
+    if (!poolStatsData?.pools || !selectedPoolInfo?.scope) return null;
+    const scopeStr = selectedPoolInfo.scope.toString();
+    const ps = poolStatsData.pools.find((p) => p.scope === scopeStr);
+    const usdStr = ps?.acceptedDepositsValueUsd ?? ps?.totalInPoolValueUsd;
+    const tokensStr = ps?.acceptedDepositsValue ?? ps?.totalInPoolValue;
+    if (!usdStr || !tokensStr) return null;
+    const usd = parseFloat(String(usdStr).replace(/,/g, ''));
+    if (!Number.isFinite(usd) || usd <= 0) return null;
+    let tokens: number;
+    try {
+      tokens = Number(formatUnits(BigInt(tokensStr), selectedPoolInfo.assetDecimals || 18));
+    } catch {
+      return null;
+    }
+    if (tokens <= 0) return null;
+    return usd / tokens;
+  }, [poolStatsData, selectedPoolInfo]);
+
+  // Live token price from Alchemy/conversion if available, otherwise fall
+  // back to the price derived from the ASP pool stats. Exposed to all
+  // consumers via context.price so the withdraw review modal, fee breakdown,
+  // pool page and anywhere else stay consistent.
+  const effectivePrice = price ?? derivedPriceFromStats;
+
   const feesQueries = useQueries({
     queries: activeRelayers.map((relayer) => ({
       queryKey: ['relayerFees', relayer.url, chainId, selectedPoolInfo?.assetAddress],
@@ -260,8 +300,16 @@ export const ChainProvider = ({ children }: Props) => {
     }
   }, [hasSomeRelayerAvailable, allQueriesAreLoading, addNotification]);
 
-  // Effect to ensure the relayer selection is always valid
+  // Effect to ensure the relayer selection is always valid.
+  //
+  // Wait for every relayer's /details query to finish before doing the
+  // auto-select. Otherwise the first relayer to respond (e.g. a faster
+  // secondary relayer) wins the default slot and the configured primary
+  // (Fast Relay) never gets re-selected once it loads, because the effect
+  // sees a valid current selection and bails out.
   useEffect(() => {
+    if (allQueriesAreLoading) return;
+
     const firstAvailable = relayersData.find((r) => r.isSelectable);
     const isCurrentSelectedStillValid = selectedRelayer
       ? relayersData.some((r) => r.url === selectedRelayer.url && r.isSelectable)
@@ -280,7 +328,7 @@ export const ChainProvider = ({ children }: Props) => {
         handleSetSelectedRelayer(undefined);
       }
     }
-  }, [relayersData, selectedRelayer, handleSetSelectedRelayer]);
+  }, [allQueriesAreLoading, relayersData, selectedRelayer, handleSetSelectedRelayer]);
 
   const contextValue = useMemo(
     () => ({
@@ -289,7 +337,7 @@ export const ChainProvider = ({ children }: Props) => {
       balanceBN,
       balanceInPoolBN,
       setBalanceInPool: handleSetBalanceInPool,
-      price,
+      price: effectivePrice,
       nativeAssetPrice,
       refetchPrice,
       maxDeposit: selectedPoolInfo?.maxDeposit.toString() ?? '0',
@@ -313,7 +361,7 @@ export const ChainProvider = ({ children }: Props) => {
       balanceBN,
       balanceInPoolBN,
       handleSetBalanceInPool,
-      price,
+      effectivePrice,
       nativeAssetPrice,
       refetchPrice,
       selectedPoolInfo,

--- a/src/utils/fetchTokenPrice.ts
+++ b/src/utils/fetchTokenPrice.ts
@@ -135,7 +135,9 @@ export const fetchTokenPrice = async (
       // Get the price of the underlying asset
       const underlyingResponse = await fetch(`${url}symbols=${underlyingAsset}`, options);
       const underlyingJson = await underlyingResponse.json();
-      let underlyingPrice = underlyingJson.data?.[0]?.prices?.[0]?.value;
+      const rawUnderlyingPrice = underlyingJson.data?.[0]?.prices?.[0]?.value;
+      let underlyingPrice =
+        rawUnderlyingPrice != null && Number.isFinite(Number(rawUnderlyingPrice)) ? Number(rawUnderlyingPrice) : 0;
 
       // Use fallback price for stablecoins not supported by Alchemy
       if (!underlyingPrice && STABLECOIN_FALLBACK_PRICES[underlyingAsset]) {
@@ -159,9 +161,16 @@ export const fetchTokenPrice = async (
   // Standard price fetch from Alchemy
   const response = await fetch(`${url}symbols=${symbol}`, options);
   const json = await response.json();
-  const value = json.data?.[0]?.prices?.[0]?.value;
-  if (!value && STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
-    return STABLECOIN_FALLBACK_PRICES[symbol];
+  // Alchemy returns price values as JSON strings (e.g. "0.9998"). Coerce to a
+  // number so callers that expect a number (e.g. `getUsdBalance` calls
+  // `price.toFixed`) don't silently throw and return $0.
+  const rawValue = json.data?.[0]?.prices?.[0]?.value;
+  const numericValue = rawValue != null ? Number(rawValue) : NaN;
+  if (!Number.isFinite(numericValue) || numericValue === 0) {
+    if (STABLECOIN_FALLBACK_PRICES[symbol] !== undefined) {
+      return STABLECOIN_FALLBACK_PRICES[symbol];
+    }
+    return 0;
   }
-  return value || 0;
+  return numericValue;
 };


### PR DESCRIPTION
## What this fixes

Two related issues on the multi-relayer withdraw flow, both in `src/providers/ChainProvider.tsx`.

### 1. Cloaked sometimes wins the default relayer slot instead of Fast Relay

The effect that auto-selects a relayer was firing on every query update. When the secondary relayer's `/details` endpoint responds faster than Fast Relay's, the timeline is:

1. Initial state: `selectedRelayer = Fast Relay` (from configured order)
2. Cloaked's query resolves first → `relayersData` shows Cloaked as `isSelectable: true`, Fast Relay still loading (`isSelectable: false`)
3. Effect runs, `firstAvailable = Cloaked`, current selection is Fast Relay which is currently `isSelectable: false` → switches to Cloaked
4. Fast Relay's query finishes → effect re-runs, but Cloaked is still valid so it bails out
5. User is now stuck on Cloaked even though Fast Relay is up

Fix: wait until **all** relayer queries have resolved (success or error) before doing the auto-select. Then `find(isSelectable)` returns the first in configured order, which is Fast Relay.

### 2. Review modal shows `$0.00 USD` even when token has a known price

The withdraw review modal (and other surfaces) read `price` directly from `ChainContext`. When Alchemy doesn't list a token, returns 0, or hasn't loaded yet, the modal renders `Total Withdrawn 50 USDS / $0.00`. PoolPage already worked around this by deriving a per-token price from the ASP pool stats (`acceptedDepositsValueUsd / acceptedDepositsValue`).

Fix: move that derivation into `ChainProvider` so every consumer of `useChainContext().price` gets the fallback automatically. This also gives accurate prices for yield-bearing tokens like sUSDS (real value ~$1.10) instead of pinning them at $1.

## The change

Single file: `src/providers/ChainProvider.tsx`

1. New `useQuery` for `aspClient.fetchPoolStats(asp, chainId)` (cached, 2-min refetch)
2. `derivedPriceFromStats` memo: pulls the selected pool's accepted USD + token amount and computes a per-token price
3. `effectivePrice = price ?? derivedPriceFromStats` exposed as `context.price`
4. Auto-select effect now gates on `allQueriesAreLoading`

## Test plan

- [ ] Open withdraw modal on USDS — `Total Withdrawn / Total Received / Net Fee` show real USD amounts, not `$0.00`
- [ ] Open withdraw modal on sUSDS — USD amounts use the live yield-bearing price (~$1.10), not flat $1
- [ ] On a fresh page load, Fast Relay is the selected relayer in the dropdown even if Cloaked responds faster
- [ ] If Fast Relay is unavailable, Cloaked auto-selects as before