### PR TITLE
fix: remove FXN incentives badge from fxUSD pool card

### DIFF
--- a/src/containers/AllPoolsStats.tsx
+++ b/src/containers/AllPoolsStats.tsx
@@ -183,8 +183,10 @@ export const calculatePrivacyScore = (
   }
 };
 
-// Assets that have incentives and APR display
-const INCENTIVIZED_ASSETS = ['fxUSD'];
+// Assets that have incentives and APR display.
+// Empty list — FXN incentives ended. Keep the list-based gate so new
+// incentive programs can be added by appending an asset name.
+const INCENTIVIZED_ASSETS: string[] = [];
 
 // FXN incentives configuration
 const FXUSD_INCENTIVES_CONFIG = {


### PR DESCRIPTION
## What this changes

FXN incentives are no longer running, so the `340% APR` tag with the `Rollover` badge and the `Incentives` indicator on the fxUSD pool card shouldn't be displayed anymore.

## The change

One line in `src/containers/AllPoolsStats.tsx`:

```diff
-const INCENTIVIZED_ASSETS = ['fxUSD'];
+const INCENTIVIZED_ASSETS: string[] = [];
```

Both the APR tag and the Incentives indicator are already gated on `INCENTIVIZED_ASSETS.includes(pool.asset)`, so emptying the list hides them for every pool. The list-based mechanism is kept so a future incentive program can be re-enabled by appending an asset name without touching the rendering code.

## Test plan

- [ ] Open the homepage — fxUSD pool card no longer shows the APR tag, the Rollover badge or the Incentives indicator
- [ ] Pool name and total funds still render correctly
- [ ] No other pool card is affected