### PR TITLE
Release v2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.14.2] - 2026-05-18
+## [2.14.2] - 2026-05-20
 
 ### Fixed
 
 - Removed the FXN incentives badge (340% APR / Rollover / Incentives) from the fxUSD pool card; incentives are no longer running
+- Simplified the withdraw modal title to "Withdraw"
 
 ## [2.14.1] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.2] - 2026-05-18
+
+### Fixed
+
+- Removed the FXN incentives badge (340% APR / Rollover / Incentives) from the fxUSD pool card; incentives are no longer running
+
 ## [2.2.0] - 2026-03-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.14.2",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/containers/AllPoolsStats.tsx
+++ b/src/containers/AllPoolsStats.tsx
@@ -183,8 +183,10 @@ export const calculatePrivacyScore = (
   }
 };
 
-// Assets that have incentives and APR display
-const INCENTIVIZED_ASSETS = ['fxUSD'];
+// Assets that have incentives and APR display.
+// Empty list — FXN incentives ended. Keep the list-based gate so new
+// incentive programs can be added by appending an asset name.
+const INCENTIVIZED_ASSETS: string[] = [];
 
 // FXN incentives configuration
 const FXUSD_INCENTIVES_CONFIG = {

--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -513,7 +513,7 @@ export const WithdrawForm = () => {
 
   return (
     <ModalContainer>
-      <ModalTitle variant='h2'>Make a withdraw</ModalTitle>
+      <ModalTitle variant='h2'>Withdraw</ModalTitle>
 
       <DecorativeCircle />
 


### PR DESCRIPTION
## Release v2.14.2

### Fixed

- Removed the FXN incentives badge (340% APR / Rollover / Incentives) from the fxUSD pool card; incentives are no longer running
- Simplified the withdraw modal title to "Withdraw"

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.