### PR TITLE
fix: simplify withdraw modal title to 'Withdraw'

### DIFF
--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -507,7 +507,7 @@ export const WithdrawForm = () => {
 
   return (
     <ModalContainer>
-      <ModalTitle variant='h2'>Make a withdraw</ModalTitle>
+      <ModalTitle variant='h2'>Withdraw</ModalTitle>
 
       <DecorativeCircle />
 


### PR DESCRIPTION
## What this changes

The withdraw modal title read "Make a withdraw". Changed it to just "Withdraw".

## The change

One line in `src/containers/Modals/Withdraw/WithdrawForm.tsx`:

```diff
-<ModalTitle variant='h2'>Make a withdraw</ModalTitle>
+<ModalTitle variant='h2'>Withdraw</ModalTitle>
```

## Test plan

- [ ] Open the withdraw modal — title reads "Withdraw"