### PR TITLE
feat: add Privacy Relayer for Ethereum mainnet

### DIFF
--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -135,6 +135,7 @@ const mainnetChainData: ChainData = {
     relayers: [
       { name: 'Fast Relay', url: 'https://fastrelay.xyz' },
       { name: 'Cloaked Relay', url: 'https://api.clkd.xyz' },
+      { name: 'Privacy Relay', url: 'https://relayerprivacypools4.mooo.com' }
     ],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,


### PR DESCRIPTION
## Summary
Add Privacy Relayer (https://relayerprivacypools4.mooo.com) as a relayer for Ethereum mainnet.
Supports ETH on mainnet and implements the same API contract as Fast Relay.

## Verification
Endpoints live — compare responses side by side:

GET /details

curl -s 'https://relayerprivacypools4.mooo.com/relayer/details?chainId=1&assetAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' | jq .


curl -s 'https://fastrelay.xyz/relayer/details?chainId=1&assetAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' | jq .

POST /quote

curl -s -X POST 'https://relayerprivacypools4.mooo.com/relayer/quote'   -H 'Content-Type: application/json'   -d '{"chainId":1,"amount":"1000000000000000000","asset":"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE","recipient":"0x83112De2B4D3e025BFB31D750B6B5838495bBd40","extraGas":false}' | jq .


## CORS
Allowlisted origins include privacypools.com, localhost:3000, and Vercel preview URLs.