### PR TITLE
fix: activity page N no longer sticks at 'No activity found' until hard refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cypress/downloads
 # Sentry Config File
 .env.sentry-build-plugin
 src/app/sentry-example-page/
+
+.pwcheck/
+.pw-browsers/

--- a/src/components/ActivityTable.tsx
+++ b/src/components/ActivityTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Table, TableBody, TableHead, TableRow, TableCell, styled, Typography, Stack } from '@mui/material';
+import { Button, Table, TableBody, TableHead, TableRow, TableCell, styled, Typography, Stack } from '@mui/material';
 import { formatUnits } from 'viem';
 import {
   ExtendedTooltip as Tooltip,
@@ -22,11 +22,15 @@ const {
 export const ActivityTable = ({
   records,
   isLoading,
+  isError,
+  onRetry,
   view,
   size = 'large',
 }: {
   records: ActivityRecords;
   isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
   view?: 'personal' | 'global';
   size?: 'small' | 'large';
 }) => {
@@ -205,10 +209,15 @@ export const ActivityTable = ({
               <STableRow></STableRow>
             </TableBody>
           </Table>
-          <Stack alignItems='center' justifyContent='center' width='100%' height={tableBodyHeight}>
+          <Stack alignItems='center' justifyContent='center' width='100%' height={tableBodyHeight} gap='1.2rem'>
             <Typography variant='body2' color='textDisabled'>
-              {isLoading ? 'Loading...' : noRecordsMessage}
+              {isLoading ? 'Loading...' : isError ? "Couldn't load activity." : noRecordsMessage}
             </Typography>
+            {!isLoading && isError && onRetry && (
+              <Button variant='outlined' size='small' onClick={onRetry}>
+                Retry
+              </Button>
+            )}
           </Stack>
         </STableContainer>
       )}

--- a/src/containers/ActivityFull.tsx
+++ b/src/containers/ActivityFull.tsx
@@ -9,8 +9,17 @@ import { useAdvancedView } from '~/hooks';
 import { ActivityRecords } from '~/types';
 
 export const ActivityFull = () => {
-  const { ITEMS_PER_PAGE, allEventsByPage, fullPersonalActivity, globalEventsCount, isLoading, poolFilter } =
-    useAdvancedView();
+  const {
+    ITEMS_PER_PAGE,
+    allEventsByPage,
+    fullPersonalActivity,
+    globalEventsCount,
+    isLoading,
+    isPageLoading,
+    isPageError,
+    refetchByPage,
+    poolFilter,
+  } = useAdvancedView();
   const [view, setView] = useState<'global' | 'personal'>('global');
   const pathname = usePathname();
 
@@ -42,11 +51,19 @@ export const ActivityFull = () => {
       <AdvancedNavigation title={title} isLogged={true} count={totalCount} />
 
       <ActivityContainer>
-        <ActivityTable records={items as ActivityRecords} isLoading={isLoading} view={view} />
+        <ActivityTable
+          records={items as ActivityRecords}
+          isLoading={view === 'global' ? isPageLoading : isLoading}
+          isError={view === 'global' ? isPageError : false}
+          onRetry={view === 'global' ? () => refetchByPage() : undefined}
+          view={view}
+        />
 
-        <ActionMenuContainer>
-          <SPagination numberOfItems={totalCount} perPage={ITEMS_PER_PAGE} />
-        </ActionMenuContainer>
+        {totalCount > 0 && (
+          <ActionMenuContainer>
+            <SPagination numberOfItems={totalCount} perPage={ITEMS_PER_PAGE} />
+          </ActionMenuContainer>
+        )}
       </ActivityContainer>
     </>
   );

--- a/src/hooks/useAdvancedView.ts
+++ b/src/hooks/useAdvancedView.ts
@@ -17,7 +17,15 @@ export const useAdvancedView = () => {
   } = useChainContext();
   const { isLoading: isLoadingExternalServices } = useExternalServices();
   const { poolAccounts, historyData, hideEmptyPools } = useAccountContext();
-  const { globalEventsData, globalEventsByPage, isLoading: isLoadingGlobalEvents, poolFilter } = useGlobalASP();
+  const {
+    globalEventsData,
+    globalEventsByPage,
+    isLoading: isLoadingGlobalEvents,
+    isPageLoading,
+    isPageError,
+    refetchByPage,
+    poolFilter,
+  } = useGlobalASP();
 
   const allEventsByPage = globalEventsByPage?.events ?? [];
 
@@ -68,6 +76,9 @@ export const useAdvancedView = () => {
     previewPersonalActivity,
     fullPersonalActivity,
     isLoading,
+    isPageLoading: isLoadingExternalServices || isPageLoading,
+    isPageError,
+    refetchByPage,
     globalEventsCount: globalEventsByPage?.total ?? 0,
     poolFilter,
   };

--- a/src/hooks/useGlobalASP.ts
+++ b/src/hooks/useGlobalASP.ts
@@ -161,8 +161,11 @@ type EventsResponse = GlobalEventsResponse | AllEventsResponse;
 export const useGlobalASP = (): {
   isError?: boolean;
   isLoading?: boolean;
+  isPageError?: boolean;
+  isPageLoading?: boolean;
   globalEventsData: EventsResponse | undefined;
   globalEventsByPage: EventsResponse | undefined;
+  refetchByPage: () => void;
   poolFilter: PoolFilter;
 } => {
   const {
@@ -232,20 +235,42 @@ export const useGlobalASP = (): {
       return enhanceWithBrevisStatuses(response);
     },
     refetchInterval: 60000,
-    retryOnMount: false,
+    // No retryOnMount:false here — a page that failed (network blip) must
+    // refetch when the user navigates back to it, not stay broken until a
+    // hard refresh.
   });
 
+  // Two consumers, two states: the home preview renders the page-1 preview
+  // query (isLoading/isError), while the full activity table renders the
+  // page-N query — its state must come from THAT query, otherwise a failed
+  // or slow page renders as an empty "No activity found" with the pager at
+  // "N OF 0" (and a Retry wired to the wrong query couldn't clear it).
   const isError = globalEventsQuery.isError;
   const isLoading = globalEventsQuery.isLoading;
+  const isPageError = globalEventsByPageQuery.isError;
+  const isPageLoading = globalEventsByPageQuery.isLoading;
+  const refetchByPage = globalEventsByPageQuery.refetch;
 
   return useMemo(
     () => ({
       isError,
       isLoading,
+      isPageError,
+      isPageLoading,
       globalEventsData: globalEventsQuery.data,
       globalEventsByPage: globalEventsByPageQuery.data,
+      refetchByPage,
       poolFilter,
     }),
-    [isError, isLoading, globalEventsQuery.data, globalEventsByPageQuery.data, poolFilter],
+    [
+      isError,
+      isLoading,
+      isPageError,
+      isPageLoading,
+      globalEventsQuery.data,
+      globalEventsByPageQuery.data,
+      refetchByPage,
+      poolFilter,
+    ],
   );
 };


### PR DESCRIPTION
Fixes the tracker breaking on `/activity/global?page=4` (any page N): a transient API blip left the table stuck on "No activity found" with the pager reading "4 OF 0" until a hard browser refresh.

**Root cause** (`useGlobalASP`):
- the table renders the page-N query, but `isLoading`/`isError` came from the page-1 preview query — a failed/slow page rendered as a confident empty state;
- the page query had `retryOnMount: false`, so after react-query exhausted its retries the page stayed broken for the whole session.

**Changes**
- Table state comes from the page query: loading shows "Loading...", a final failure shows "Couldn't load activity." with a **Retry** button wired to that query.
- Dropped `retryOnMount: false` on the page query — navigating back to a failed page self-heals.
- Home preview keeps its own preview-query state (unaffected by a broken page query).
- Pagination hidden at zero items, killing the "4 OF 0" artifact in loading/error/empty states.

**Verification** (playwright, aborting the page-4 request to reproduce):
- blocked: error + Retry render, no misleading empty state, no "4 OF 0" ✅
- Retry after recovery: 12 rows render without a refresh ✅
- home preview with a broken page query: renders normally ✅
- backend checked healthy (pages 1-6 return 200 with 12 events each), so the FE wiring was the whole story.
