### PR TITLE
Release v2.14.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cypress/downloads
 # Sentry Config File
 .env.sentry-build-plugin
 src/app/sentry-example-page/
+
+.pwcheck/
+.pw-browsers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.3] - 2026-07-03
+
+### Fixed
+
+- Global activity pages no longer get stuck on "No activity found" with the pager reading "4 OF 0" after a transient API failure — the table's loading/error state now tracks the paginated query itself (it previously tracked only the first-page preview), failures show a "Couldn't load activity." message with a Retry button, and navigating back to a failed page refetches instead of staying broken until a hard refresh
+- Pagination is hidden when there are no items, so the "N OF 0" state can no longer appear while loading or after an error
+
 ## [2.14.2] - 2026-05-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.14.2",
+  "version": "2.14.3",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/components/ActivityTable.tsx
+++ b/src/components/ActivityTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Table, TableBody, TableHead, TableRow, TableCell, styled, Typography, Stack } from '@mui/material';
+import { Button, Table, TableBody, TableHead, TableRow, TableCell, styled, Typography, Stack } from '@mui/material';
 import { formatUnits } from 'viem';
 import {
   ExtendedTooltip as Tooltip,
@@ -22,11 +22,15 @@ const {
 export const ActivityTable = ({
   records,
   isLoading,
+  isError,
+  onRetry,
   view,
   size = 'large',
 }: {
   records: ActivityRecords;
   isLoading?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
   view?: 'personal' | 'global';
   size?: 'small' | 'large';
 }) => {
@@ -205,10 +209,15 @@ export const ActivityTable = ({
               <STableRow></STableRow>
             </TableBody>
           </Table>
-          <Stack alignItems='center' justifyContent='center' width='100%' height={tableBodyHeight}>
+          <Stack alignItems='center' justifyContent='center' width='100%' height={tableBodyHeight} gap='1.2rem'>
             <Typography variant='body2' color='textDisabled'>
-              {isLoading ? 'Loading...' : noRecordsMessage}
+              {isLoading ? 'Loading...' : isError ? "Couldn't load activity." : noRecordsMessage}
             </Typography>
+            {!isLoading && isError && onRetry && (
+              <Button variant='outlined' size='small' onClick={onRetry}>
+                Retry
+              </Button>
+            )}
           </Stack>
         </STableContainer>
       )}

--- a/src/containers/ActivityFull.tsx
+++ b/src/containers/ActivityFull.tsx
@@ -9,8 +9,17 @@ import { useAdvancedView } from '~/hooks';
 import { ActivityRecords } from '~/types';
 
 export const ActivityFull = () => {
-  const { ITEMS_PER_PAGE, allEventsByPage, fullPersonalActivity, globalEventsCount, isLoading, poolFilter } =
-    useAdvancedView();
+  const {
+    ITEMS_PER_PAGE,
+    allEventsByPage,
+    fullPersonalActivity,
+    globalEventsCount,
+    isLoading,
+    isPageLoading,
+    isPageError,
+    refetchByPage,
+    poolFilter,
+  } = useAdvancedView();
   const [view, setView] = useState<'global' | 'personal'>('global');
   const pathname = usePathname();
 
@@ -42,11 +51,19 @@ export const ActivityFull = () => {
       <AdvancedNavigation title={title} isLogged={true} count={totalCount} />
 
       <ActivityContainer>
-        <ActivityTable records={items as ActivityRecords} isLoading={isLoading} view={view} />
+        <ActivityTable
+          records={items as ActivityRecords}
+          isLoading={view === 'global' ? isPageLoading : isLoading}
+          isError={view === 'global' ? isPageError : false}
+          onRetry={view === 'global' ? () => refetchByPage() : undefined}
+          view={view}
+        />
 
-        <ActionMenuContainer>
-          <SPagination numberOfItems={totalCount} perPage={ITEMS_PER_PAGE} />
-        </ActionMenuContainer>
+        {totalCount > 0 && (
+          <ActionMenuContainer>
+            <SPagination numberOfItems={totalCount} perPage={ITEMS_PER_PAGE} />
+          </ActionMenuContainer>
+        )}
       </ActivityContainer>
     </>
   );

--- a/src/containers/Modals/Withdraw/WithdrawForm.tsx
+++ b/src/containers/Modals/Withdraw/WithdrawForm.tsx
@@ -507,7 +507,7 @@ export const WithdrawForm = () => {
 
   return (
     <ModalContainer>
-      <ModalTitle variant='h2'>Make a withdraw</ModalTitle>
+      <ModalTitle variant='h2'>Withdraw</ModalTitle>
 
       <DecorativeCircle />
 

--- a/src/hooks/useAdvancedView.ts
+++ b/src/hooks/useAdvancedView.ts
@@ -17,7 +17,15 @@ export const useAdvancedView = () => {
   } = useChainContext();
   const { isLoading: isLoadingExternalServices } = useExternalServices();
   const { poolAccounts, historyData, hideEmptyPools } = useAccountContext();
-  const { globalEventsData, globalEventsByPage, isLoading: isLoadingGlobalEvents, poolFilter } = useGlobalASP();
+  const {
+    globalEventsData,
+    globalEventsByPage,
+    isLoading: isLoadingGlobalEvents,
+    isPageLoading,
+    isPageError,
+    refetchByPage,
+    poolFilter,
+  } = useGlobalASP();
 
   const allEventsByPage = globalEventsByPage?.events ?? [];
 
@@ -68,6 +76,9 @@ export const useAdvancedView = () => {
     previewPersonalActivity,
     fullPersonalActivity,
     isLoading,
+    isPageLoading: isLoadingExternalServices || isPageLoading,
+    isPageError,
+    refetchByPage,
     globalEventsCount: globalEventsByPage?.total ?? 0,
     poolFilter,
   };

--- a/src/hooks/useGlobalASP.ts
+++ b/src/hooks/useGlobalASP.ts
@@ -161,8 +161,11 @@ type EventsResponse = GlobalEventsResponse | AllEventsResponse;
 export const useGlobalASP = (): {
   isError?: boolean;
   isLoading?: boolean;
+  isPageError?: boolean;
+  isPageLoading?: boolean;
   globalEventsData: EventsResponse | undefined;
   globalEventsByPage: EventsResponse | undefined;
+  refetchByPage: () => void;
   poolFilter: PoolFilter;
 } => {
   const {
@@ -232,20 +235,42 @@ export const useGlobalASP = (): {
       return enhanceWithBrevisStatuses(response);
     },
     refetchInterval: 60000,
-    retryOnMount: false,
+    // No retryOnMount:false here — a page that failed (network blip) must
+    // refetch when the user navigates back to it, not stay broken until a
+    // hard refresh.
   });
 
+  // Two consumers, two states: the home preview renders the page-1 preview
+  // query (isLoading/isError), while the full activity table renders the
+  // page-N query — its state must come from THAT query, otherwise a failed
+  // or slow page renders as an empty "No activity found" with the pager at
+  // "N OF 0" (and a Retry wired to the wrong query couldn't clear it).
   const isError = globalEventsQuery.isError;
   const isLoading = globalEventsQuery.isLoading;
+  const isPageError = globalEventsByPageQuery.isError;
+  const isPageLoading = globalEventsByPageQuery.isLoading;
+  const refetchByPage = globalEventsByPageQuery.refetch;
 
   return useMemo(
     () => ({
       isError,
       isLoading,
+      isPageError,
+      isPageLoading,
       globalEventsData: globalEventsQuery.data,
       globalEventsByPage: globalEventsByPageQuery.data,
+      refetchByPage,
       poolFilter,
     }),
-    [isError, isLoading, globalEventsQuery.data, globalEventsByPageQuery.data, poolFilter],
+    [
+      isError,
+      isLoading,
+      isPageError,
+      isPageLoading,
+      globalEventsQuery.data,
+      globalEventsByPageQuery.data,
+      refetchByPage,
+      poolFilter,
+    ],
   );
 };


### PR DESCRIPTION
## Release v2.14.3

### Fixed

- Global activity pages no longer get stuck on "No activity found" with the pager reading "4 OF 0" after a transient API failure — the table's loading/error state now tracks the paginated query itself, failures show a "Couldn't load activity." message with a Retry button, and navigating back to a failed page refetches instead of staying broken until a hard refresh
- Pagination is hidden when there are no items, so the "N OF 0" state can no longer appear while loading or after an error

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [x] If it is a core feature, I have included comprehensive tests.
