### PR TITLE
Add Phasx relayer

### DIFF
--- a/src/config/chainData.ts
+++ b/src/config/chainData.ts
@@ -135,6 +135,7 @@ const mainnetChainData: ChainData = {
     relayers: [
       { name: 'Fast Relay', url: 'https://fastrelay.xyz' },
       { name: 'Cloaked Relay', url: 'https://api.clkd.xyz' },
+      { name: 'Phasx Relay', url: 'https://privacy-pools.phasx.pro' },
     ],
     sdkRpcUrl: `/api/hypersync-rpc?chainId=1`, // Secure Hypersync proxy (relative URL)
     rpcUrl: `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`,


### PR DESCRIPTION
## Summary

This PR adds Phasx as a new relayer option for Privacy Pools.

Relayer endpoint:

https://privacy-pools.phasx.pro

## Verification

Verified the relayer details endpoint for Ethereum mainnet native ETH:

https://privacy-pools.phasx.pro/relayer/details?chainId=1&assetAddress=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE

The endpoint returns the expected relayer configuration, including fee, fee receiver, chain ID, asset address, minimum withdrawal amount, and max gas price.

Also verified a successful relayed withdrawal on Ethereum mainnet:

https://etherscan.io/tx/0xf719e0fa007d19c336b7f902e8cd870a94b028002181e1e89f2a3c4a8d1b16e3

## Notes
Supports 14 assets on Ethereum.

This change only adds a new relayer option and does not modify the existing relayer configurations.