### PR TITLE
Release v2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.4] - 2026-08-03
+
+### Fixed
+
+- Withdrawal review totals no longer collapse at the thousands separator — "Total Withdrawn"/"Total Received" for any amount worth ≥ $1,000 displayed only its leading digits (e.g. 3 ETH → "$5.00") because the Intl-formatted USD string was re-parsed with parseFloat, which stops at the comma; formatted USD strings are now rendered directly, which also fixes dust amounts rendering as "$NaN"
+- Activity details now price each row by its own asset instead of the currently selected pool's price, so a global USDT deposit no longer shows an ETH-priced USD value (~$75M for ~$40k)
+- Net Fee no longer double-counts the Extra Gas amount: the relayer's quoted fee is already gas-adjusted, so Net Fee now reconciles with Total Withdrawn − Total Received (the removed local conversion also used a broken formula that inflated Net Fee ~1,800× on ETH pools when Extra Gas was enabled)
+- The deposit review "Value" row renders again — it was gated on withdrawal-quote state a deposit never reaches
+- Sub-precision stablecoin net fees (e.g. 0.0004 USDC) are no longer displayed as 0, and a zero fee no longer renders as "0.00e+0"
+- USD conversion divisor is computed with bigint exponentiation to stay exact at high token decimals
+
 ## [2.14.3] - 2026-07-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "privacy-pools-website",
   "private": true,
-  "version": "2.14.3",
+  "version": "2.14.4",
   "type": "module",
   "license": "MIT",
   "author": "Wonderland",

--- a/src/containers/Modals/ActivityDetails/DataSection.tsx
+++ b/src/containers/Modals/ActivityDetails/DataSection.tsx
@@ -3,7 +3,13 @@
 import { Stack, styled, Typography } from '@mui/material';
 import { formatUnits } from 'viem';
 import { ExtendedTooltip as Tooltip } from '~/components';
-import { useExternalServices, usePoolAccountsContext, useChainContext, useTransactionFee } from '~/hooks';
+import {
+  useExternalServices,
+  usePoolAccountsContext,
+  useChainContext,
+  useTransactionFee,
+  useActivityAssetPrice,
+} from '~/hooks';
 import { EventType, GlobalEvent } from '~/types';
 import { formatDataNumber, formatTimestamp, getUsdBalance, truncateAddress } from '~/utils';
 
@@ -11,8 +17,8 @@ export const DataSection = () => {
   const {
     selectedPoolInfo: { assetDecimals, asset, entryPointAddress },
     balanceBN: { decimals: balanceDecimals },
-    price,
   } = useChainContext();
+  const price = useActivityAssetPrice();
   const { vettingFeeBPS, selectedHistoryData } = usePoolAccountsContext();
   const { currentSelectedRelayerData } = useExternalServices();
   const isDeposit = selectedHistoryData?.type === EventType.DEPOSIT;

--- a/src/containers/Modals/ActivityDetails/Resume.tsx
+++ b/src/containers/Modals/ActivityDetails/Resume.tsx
@@ -3,7 +3,7 @@ import { Stack, Typography, styled } from '@mui/material';
 import { formatUnits } from 'viem';
 import { ExtendedTooltip as Tooltip, StatusChip } from '~/components';
 import { getConstants } from '~/config/constants';
-import { useAccountContext, usePoolAccountsContext, useChainContext } from '~/hooks';
+import { useAccountContext, usePoolAccountsContext, useChainContext, useActivityAssetPrice } from '~/hooks';
 import { GlobalEvent, ReviewStatus } from '~/types';
 import { getUsdBalance, getStatus } from '~/utils';
 
@@ -12,10 +12,10 @@ export const Resume = () => {
   const { poolAccounts } = useAccountContext();
   const { selectedHistoryData } = usePoolAccountsContext();
   const {
-    price,
     balanceBN: { decimals: balanceDecimals },
     selectedPoolInfo: { assetDecimals, asset },
   } = useChainContext();
+  const price = useActivityAssetPrice();
 
   const isGlobal = selectedHistoryData && 'pool' in selectedHistoryData;
   const globalEvent = isGlobal ? (selectedHistoryData as unknown as GlobalEvent) : null;

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -176,7 +176,7 @@ export const DataSection = () => {
   const amountWithFee = formatUnits(amountWithFeeBN, decimals);
   const amountWithFeeUSD = getUsdBalance(price, amountWithFee, decimals);
   const valueText = price
-    ? `${parseFloat(amountWithFee).toString()} ${displaySymbol} (~$${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)} USD)`
+    ? `${parseFloat(amountWithFee).toString()} ${displaySymbol} (~${amountWithFeeUSD} USD)`
     : `${parseFloat(amountWithFee).toString()} ${displaySymbol}`;
   const valueTooltip = `${formatFullPrecision(amountWithFeeBN, decimals)} ${displaySymbol}`;
 
@@ -200,7 +200,7 @@ export const DataSection = () => {
   const netFeeDisplayValue = parseFloat(netFeeNumeric.toFixed(netFeePrecision)).toString();
 
   const netFeeText = price
-    ? `${netFeeDisplayValue} ${displaySymbol} (~$${parseFloat(netFeeUSD.replace('$', '')).toFixed(2)} USD)`
+    ? `${netFeeDisplayValue} ${displaySymbol} (~${netFeeUSD} USD)`
     : `${netFeeDisplayValue} ${displaySymbol}`;
   const netFeeTooltip = `${formatFullPrecision(netFeeAmount, decimals)} ${displaySymbol}`;
 
@@ -334,7 +334,7 @@ export const DataSection = () => {
                 {formatFeeDisplay(totalAmountBN, symbol, decimals, price, isStableAsset).displayText.split(' (~')[0]}
               </TotalAmount>
             </Tooltip>
-            {price && <TotalUSD>${parseFloat(amountUSD.replace('$', '')).toFixed(2)}</TotalUSD>}
+            {price && <TotalUSD>{amountUSD}</TotalUSD>}
           </TotalBox>
 
           <TotalBox>
@@ -344,7 +344,7 @@ export const DataSection = () => {
                 {formatFeeDisplay(amountWithFeeBN, symbol, decimals, price, isStableAsset).displayText.split(' (~')[0]}
               </TotalAmount>
             </Tooltip>
-            {price && <TotalUSD>${parseFloat(amountWithFeeUSD.replace('$', '')).toFixed(2)}</TotalUSD>}
+            {price && <TotalUSD>{amountWithFeeUSD}</TotalUSD>}
           </TotalBox>
 
           {!price && (

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -36,6 +36,7 @@ export const DataSection = () => {
   const {
     balanceBN: { symbol, decimals },
     price,
+    nativeAssetPrice,
     refetchPrice,
     selectedPoolInfo,
     chainId,
@@ -182,10 +183,10 @@ export const DataSection = () => {
 
   // Net Fee calculation (includes extra gas amount if enabled)
   let netFeeAmount = fees;
-  if (quoteState.extraGas && quoteExtraGasAmountETH && price) {
-    // Convert extraGasAmountETH from wei to token amount
+  if (quoteState.extraGas && quoteExtraGasAmountETH && price && nativeAssetPrice) {
+    // Extra gas is denominated in the native asset; convert to pool-token units via USD prices
     const extraGasETH = parseFloat(formatUnits(BigInt(quoteExtraGasAmountETH), 18));
-    const extraGasInToken = (extraGasETH * price) / parseFloat(formatUnits(parseUnits('1', decimals), decimals));
+    const extraGasInToken = (extraGasETH * nativeAssetPrice) / price;
 
     // Convert to fixed decimal string to avoid scientific notation
     const extraGasAmountBN = parseUnits(extraGasInToken.toFixed(decimals), decimals);

--- a/src/containers/Modals/Review/DataSection.tsx
+++ b/src/containers/Modals/Review/DataSection.tsx
@@ -36,7 +36,6 @@ export const DataSection = () => {
   const {
     balanceBN: { symbol, decimals },
     price,
-    nativeAssetPrice,
     refetchPrice,
     selectedPoolInfo,
     chainId,
@@ -181,24 +180,23 @@ export const DataSection = () => {
     : `${parseFloat(amountWithFee).toString()} ${displaySymbol}`;
   const valueTooltip = `${formatFullPrecision(amountWithFeeBN, decimals)} ${displaySymbol}`;
 
-  // Net Fee calculation (includes extra gas amount if enabled)
-  let netFeeAmount = fees;
-  if (quoteState.extraGas && quoteExtraGasAmountETH && price && nativeAssetPrice) {
-    // Extra gas is denominated in the native asset; convert to pool-token units via USD prices
-    const extraGasETH = parseFloat(formatUnits(BigInt(quoteExtraGasAmountETH), 18));
-    const extraGasInToken = (extraGasETH * nativeAssetPrice) / price;
-
-    // Convert to fixed decimal string to avoid scientific notation
-    const extraGasAmountBN = parseUnits(extraGasInToken.toFixed(decimals), decimals);
-    netFeeAmount = fees + extraGasAmountBN;
-  }
+  // Net Fee comes straight from the quoted feeBPS: the relayer's quote is
+  // gas-adjusted and refetched when extra gas toggles, so the extra-gas
+  // funding is already included — adding it again would double-count it and
+  // desync Net Fee from Total Withdrawn - Total Received.
+  const netFeeAmount = fees;
   const netFeeFormatted = formatUnits(netFeeAmount, decimals);
   const netFeeUSD = getUsdBalance(price, netFeeFormatted, decimals);
 
   // Net fee uses the same precision logic as fee breakdown
   const netFeePrecision = getMaxDisplayPrecision(isStableAsset);
   const netFeeNumeric = parseFloat(netFeeFormatted);
-  const netFeeDisplayValue = parseFloat(netFeeNumeric.toFixed(netFeePrecision)).toString();
+  const netFeeDisplayValue =
+    netFeeNumeric === 0
+      ? '0'
+      : netFeeNumeric < Math.pow(10, -netFeePrecision)
+        ? netFeeNumeric.toExponential(2)
+        : parseFloat(netFeeNumeric.toFixed(netFeePrecision)).toString();
 
   const netFeeText = price
     ? `${netFeeDisplayValue} ${displaySymbol} (~${netFeeUSD} USD)`
@@ -280,7 +278,7 @@ export const DataSection = () => {
               )}
             </Row>
           )}
-          {actionType !== EventType.WITHDRAWAL && (isQuoteValid || isExpired) && (
+          {actionType !== EventType.WITHDRAWAL && (
             <Row>
               <Label variant='body2'>Value:</Label>
               <Tooltip title={valueTooltip} placement='top'>

--- a/src/containers/Modals/Review/FeeBreakdown.tsx
+++ b/src/containers/Modals/Review/FeeBreakdown.tsx
@@ -49,9 +49,7 @@ export const formatFeeDisplay = (
     return { displayText: `${displayValue} ${symbol}`, fullPrecision, usdValue: '' };
   }
 
-  const usdValue = getUsdBalance(price, feeInToken, decimals);
-  const usdNumeric = parseFloat(usdValue.replace('$', ''));
-  const usdFormatted = `$${usdNumeric.toFixed(2)}`;
+  const usdFormatted = getUsdBalance(price, feeInToken, decimals);
 
   const displayText = `${displayValue} ${symbol} (~${usdFormatted} USD)`;
 

--- a/src/containers/Modals/Review/FeeBreakdown.tsx
+++ b/src/containers/Modals/Review/FeeBreakdown.tsx
@@ -41,9 +41,11 @@ export const formatFeeDisplay = (
 
   // For display, use precision based on asset type
   const displayValue =
-    feeNumeric < Math.pow(10, -displayPrecision)
-      ? feeNumeric.toExponential(2)
-      : parseFloat(feeNumeric.toFixed(displayPrecision)).toString();
+    feeNumeric === 0
+      ? '0'
+      : feeNumeric < Math.pow(10, -displayPrecision)
+        ? feeNumeric.toExponential(2)
+        : parseFloat(feeNumeric.toFixed(displayPrecision)).toString();
 
   if (!price) {
     return { displayText: `${displayValue} ${symbol}`, fullPrecision, usdValue: '' };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -25,4 +25,5 @@ export * from './context/useAuthContext';
 export * from './context/useNotificationsContext';
 export * from './useFeatureFlag';
 export * from './useTransactionFee';
+export * from './useActivityAssetPrice';
 export * from './useSelfReport';

--- a/src/hooks/useActivityAssetPrice.ts
+++ b/src/hooks/useActivityAssetPrice.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { chainData } from '~/config';
+import { useChainContext, usePoolAccountsContext } from '~/hooks';
+import { GlobalEvent } from '~/types';
+import { fetchTokenPrice } from '~/utils';
+
+const allPools = Object.values(chainData).flatMap((chain) => chain.poolInfo);
+
+/**
+ * USD price for the asset of the currently selected activity row.
+ *
+ * Personal history rows always belong to the selected pool, so the chain
+ * context price applies. Global rows can be for any pool on any chain, so
+ * pricing them with the selected pool's price is wrong (e.g. a USDT deposit
+ * priced at the ETH rate) — resolve the row's own asset price instead, and
+ * return null when it can't be resolved so callers hide the USD value.
+ */
+export const useActivityAssetPrice = (): number | null => {
+  const { price, selectedPoolInfo } = useChainContext();
+  const { selectedHistoryData } = usePoolAccountsContext();
+
+  const globalEvent =
+    selectedHistoryData && 'pool' in selectedHistoryData ? (selectedHistoryData as unknown as GlobalEvent) : null;
+
+  const rowTokenAddress = globalEvent?.pool.tokenAddress?.toLowerCase();
+  const rowSymbol = globalEvent?.pool.tokenSymbol;
+
+  const matchesSelectedPool =
+    !globalEvent ||
+    (globalEvent.pool.chainId === selectedPoolInfo?.chainId &&
+      (rowTokenAddress === selectedPoolInfo?.assetAddress?.toLowerCase() ||
+        rowSymbol?.toLowerCase() === selectedPoolInfo?.asset?.toLowerCase()));
+
+  const rowPoolInfo = globalEvent
+    ? allPools.find(
+        (pool) =>
+          pool.chainId === globalEvent.pool.chainId &&
+          (pool.assetAddress.toLowerCase() === rowTokenAddress ||
+            pool.asset.toLowerCase() === rowSymbol?.toLowerCase()),
+      )
+    : undefined;
+
+  const { data: fetchedPrice } = useQuery({
+    queryKey: ['activityAssetPrice', globalEvent?.pool.chainId, rowSymbol],
+    queryFn: () => fetchTokenPrice(rowSymbol ?? '', rowPoolInfo),
+    enabled: !!globalEvent && !matchesSelectedPool && !!rowSymbol,
+    staleTime: 60_000,
+  });
+
+  if (matchesSelectedPool) return price;
+  return fetchedPrice && fetchedPrice > 0 ? fetchedPrice : null;
+};

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -9,7 +9,7 @@ export const getUsdBalance = (price: number | null, balance: string, decimals: n
     const priceStr = price.toFixed(decimals);
     const priceBN = parseUnits(priceStr, decimals);
     const balanceBN = parseUnits(balance, decimals);
-    const result = (priceBN * balanceBN) / BigInt(10 ** decimals);
+    const result = (priceBN * balanceBN) / BigInt(10) ** BigInt(decimals);
     return formatDataNumber(result.toString(), decimals, 2, true, false);
   } catch {
     return '0';


### PR DESCRIPTION
## Release v2.14.4

### Fixed

- Withdrawal review totals no longer collapse at the thousands separator — "Total Withdrawn"/"Total Received" for any amount worth ≥ $1,000 displayed only its leading digits (e.g. 3 ETH → "$5.00") because the Intl-formatted USD string was re-parsed with parseFloat, which stops at the comma; formatted USD strings are now rendered directly, which also fixes dust amounts rendering as "$NaN"
- Activity details now price each row by its own asset instead of the currently selected pool's price, so a global USDT deposit no longer shows an ETH-priced USD value (~$75M for ~$40k)
- Net Fee no longer double-counts the Extra Gas amount: the relayer's quoted fee is already gas-adjusted, so Net Fee now reconciles with Total Withdrawn − Total Received (the removed local conversion also used a broken formula that inflated Net Fee ~1,800× on ETH pools when Extra Gas was enabled)
- The deposit review "Value" row renders again — it was gated on withdrawal-quote state a deposit never reaches
- Sub-precision stablecoin net fees (e.g. 0.0004 USDC) are no longer displayed as 0, and a zero fee no longer renders as "0.00e+0"
- USD conversion divisor is computed with bigint exponentiation to stay exact at high token decimals

## Checklist before requesting a review

- [x] I have conducted a self-review of my code.
- [x] I have conducted a QA.
- [ ] If it is a core feature, I have included comprehensive tests.